### PR TITLE
Use our own Docker image for builds on Bitbucket and Codeship

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Supported Technologies and Services
    :target: https://bitbucket.org/painless-software/painless-continuous-delivery/addon/pipelines/home
 .. |codeship| image:: https://img.shields.io/codeship/64f85000-617f-0134-d666-52056d8a95f1/master.svg
    :alt: Codeship
-   :target: https://codeship.com/projects/174831
+   :target: https://app.codeship.com/projects/174831
 .. |gitlab-ci| image:: https://gitlab.com/painless-software/painless-continuous-delivery/badges/master/build.svg
    :alt: GitLab CI
    :target: https://gitlab.com/painless-software/painless-continuous-delivery

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 # Painless deployment with Bitbucket Pipelines.
 # Visit the docs at https://confluence.atlassian.com/x/VYk8Lw
 
-image: themattrix/tox
+image: painless/tox
 pipelines:
   default:
     - step:

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -5,6 +5,6 @@ version: '2'
 
 services:
   app:
-    image: themattrix/tox
+    image: painless/tox
     volumes:
       - .:/app

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,8 +1,10 @@
-# Painless development and deployment with Docker.
-# Visit the docs at https://docs.docker.com/compose/
-# Codeship specific docs: https://documentation.codeship.com/docker/services/
+# Painless deployment with Codeship.
+# Visit the docs at https://documentation.codeship.com/pro/getting-started/services/#services-file-setup--configuration
 
-app:
-  image: themattrix/tox
-  volumes:
-    - .:/app
+version: '2'
+
+services:
+  app:
+    image: themattrix/tox
+    volumes:
+      - .:/app

--- a/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 # Painless deployment with Bitbucket Pipelines.
 # Visit the docs at https://confluence.atlassian.com/x/VYk8Lw
 
-image: themattrix/tox
+image: painless/tox
 pipelines:
   default:
     - step:

--- a/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
@@ -5,6 +5,6 @@ version: '2'
 
 services:
   app:
-    image: themattrix/tox
+    image: painless/tox
     volumes:
       - .:/app

--- a/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
@@ -1,8 +1,10 @@
-# Painless development and deployment with Docker.
-# Visit the docs at https://docs.docker.com/compose/
-# Codeship specific docs: https://documentation.codeship.com/docker/services/
+# Painless deployment with Codeship.
+# Visit the docs at https://documentation.codeship.com/pro/getting-started/services/#services-file-setup--configuration
 
-app:
-  image: themattrix/tox
-  volumes:
-    - .:/app
+version: '2'
+
+services:
+  app:
+    image: themattrix/tox
+    volumes:
+      - .:/app

--- a/{{cookiecutter.project_slug}}/config/application/uwsgi.ini
+++ b/{{cookiecutter.project_slug}}/config/application/uwsgi.ini
@@ -2,6 +2,7 @@
 cheaper = 2
 chmod-socket = 660
 chown-socket = application:application
+enable-threads = True
 master = True
 processes = 16
 python-autoreload = 1


### PR DESCRIPTION
Use our own Docker image for builds on Bitbucket and Codeship, which fixes the missing Git executable since the switch to pyenv in the themattrix/tox Docker image.