### PR TITLE
Use stages in CI setup (checks, tests)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,61 +1,54 @@
 # Painless deployment with GitLab CI.
 # Visit the docs at https://docs.gitlab.com/ce/ci/
 
-.test: &test_template
-  before_script:
-  - pip install tox
-  script: tox
+image: painless/tox
 
-test-flake8:
-  image: python:3.5
-  variables:
-    TOXENV: flake8
-  <<: *test_template
-test-pylint:
-  image: python:3.5
-  variables:
-    TOXENV: pylint
-  <<: *test_template
-test-py27:
-  image: python:2.7
-  variables:
-    TOXENV: py27
-  <<: *test_template
-test-py34:
-  image: python:3.4
-  variables:
-    TOXENV: py34
-  <<: *test_template
-test-py35:
-  image: python:3.5
-  variables:
-    TOXENV: py35
-  <<: *test_template
-test-py36:
-  image: python:3.6
-  variables:
-    TOXENV: py36
-  <<: *test_template
-test-pypy:
-  image: pypy:2
-  variables:
-    TOXENV: pypy
-  <<: *test_template
-test-behave:
-  image: python:3.5
-  variables:
-    TOXENV: behave
-  <<: *test_template
+stages:
+- check
+- test
+- deploy
+
+flake8:
+  stage: check
+  script: tox -e flake8
+
+pylint:
+  stage: check
+  script: tox -e pylint
+
+py27:
+  stage: test
+  script: tox -e py27
+
+py34:
+  stage: test
+  script: tox -e py34
+
+py35:
+  stage: test
+  script: tox -e py35
+
+py36:
+  stage: test
+  script: tox -e py36
+
+pypy:
+  stage: test
+  script: tox -e pypy
+
+behave:
+  stage: test
+  script: tox -e behave
 
 staging:
-  type: deploy
+  stage: deploy
   script:
   - echo 'This build would deploy to Staging now.'
   only:
   - master
 
 production:
-  type: deploy
+  stage: deploy
   script:
   - echo 'This build would deploy to Production now.'
   only:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -26,7 +26,8 @@
         ".travis.yml",
         "vexor.yml"
     ],
-    "tests": "flake8,py27,py35",
+    "checks": "flake8",
+    "tests": "py27,py35",
     "framework": [
         "(none)",
         "Django",

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -19,7 +19,8 @@ class TestCISetup(object):
             'vcs_remote': 'git@bitbucket.org:painless-software/myproject.git',
             'ci_service': 'bitbucket-pipelines.yml',
             'ci_testcommand': '          - tox',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
         ('codeship', {
             'project_slug': 'myproject',
@@ -28,7 +29,8 @@ class TestCISetup(object):
             'vcs_remote': 'git@bitbucket.org:painless-software/myproject.git',
             'ci_service': 'codeship-steps.yml',
             'ci_testcommand': '  service: app',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
         ('gitlab', {
             'project_slug': 'myproject',
@@ -36,8 +38,9 @@ class TestCISetup(object):
             'vcs_platform': 'GitLab.com',
             'vcs_remote': 'git@gitlab.com:painless-software/myproject.git',
             'ci_service': '.gitlab-ci.yml',
-            'ci_testcommand': '  script: tox',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'ci_testcommand': '  script: tox -e py36',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
         ('shippable', {
             'project_slug': 'myproject',
@@ -46,7 +49,8 @@ class TestCISetup(object):
             'vcs_remote': 'git@bitbucket.org:painless-software/myproject.git',
             'ci_service': 'shippable.yml',
             'ci_testcommand': '    - tox',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
         ('travis', {
             'project_slug': 'myproject',
@@ -55,7 +59,8 @@ class TestCISetup(object):
             'vcs_remote': 'git@github.com:painless-software/myproject.git',
             'ci_service': '.travis.yml',
             'ci_testcommand': 'script: tox',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
         ('vexor', {
             'project_slug': 'myproject',
@@ -64,14 +69,15 @@ class TestCISetup(object):
             'vcs_remote': 'git@github.com:painless-software/myproject.git',
             'ci_service': 'vexor.yml',
             'ci_testcommand': 'script: tox',
-            'tests': 'flake8,pylint,py27,py34,py35,py36,pypy,behave',
+            'checks': 'flake8,pylint',
+            'tests': 'py27,py34,py35,py36,pypy,behave',
         }),
     ]
 
     # pylint: disable=too-many-arguments,too-many-locals,no-self-use
     def test_ci_setup(self, cookies, project_slug,
                       vcs_account, vcs_platform, vcs_remote,
-                      ci_service, ci_testcommand, tests):
+                      ci_service, ci_testcommand, checks, tests):
         """
         Generate a CI setup with specific settings and verify it is complete.
         """
@@ -80,6 +86,7 @@ class TestCISetup(object):
             'vcs_platform': vcs_platform,
             'vcs_account': vcs_account,
             'ci_service': ci_service,
+            'checks': checks,
             'tests': tests,
         })
 

--- a/{{cookiecutter.project_slug}}/_/ci-services/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.gitlab-ci.yml
@@ -1,31 +1,31 @@
 # Painless deployment with GitLab CI.
 # Visit the docs at https://docs.gitlab.com/ce/ci/
 
-.test: &test_template
-  before_script:
-  - pip install tox
-  script: tox
-{% for env in cookiecutter.tests.split(",") %}
-test-{{ env }}:
-  {% if env in ["flake8", "pylint", "behave"] -%}
-  image: python:3.5
-  {%- elif env|truncate(2, True, "", 0) == "py" -%}
-  image: {{ env|replace("py", "python:", 1)|replace("27", "2.7")|replace("34", "3.4")|replace("35", "3.5")|replace("36", "3.6")|replace("python:py", "pypy:2") }}
-  {%- endif %}
-  variables:
-    TOXENV: {{ env }}
-  <<: *test_template
-{%- endfor %}
+image: painless/tox
 
+stages:
+- check
+- test
+- deploy
+{% for env in cookiecutter.checks.split(",") %}
+{{ env }}:
+  stage: check
+  script: tox -e {{ env }}
+{% endfor %}
+{%- for env in cookiecutter.tests.split(",") %}
+{{ env }}:
+  stage: test
+  script: tox -e {{ env }}
+{% endfor %}
 staging:
-  type: deploy
+  stage: deploy
   script:
   - echo 'This build would deploy to Staging now.'
   only:
   - master
 
 production:
-  type: deploy
+  stage: deploy
   script:
   - echo 'This build would deploy to Production now.'
   only:

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -8,6 +8,9 @@ python: 3.6
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
+    {%- for env in cookiecutter.checks.split(',') %}
+    - TOXENV={{ env }}
+    {%- endfor %}
     {%- for env in cookiecutter.tests.split(',') %}
     - TOXENV={{ env }}
     {%- endfor %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/codeship-steps.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/codeship-steps.yml
@@ -4,6 +4,10 @@
 - type: parallel
   service: app
   steps:
+    {%- for env in cookiecutter.checks.split(',') %}
+    - name: {{ env }}
+      command: tox -e {{ env }}
+    {%- endfor %}
     {%- for env in cookiecutter.tests.split(',') %}
     - name: {{ env }}
       command: tox -e {{ env }}

--- a/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
@@ -7,6 +7,9 @@ python:
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
+    {%- for env in cookiecutter.checks.split(',') %}
+    - TOXENV={{ env }}
+    {%- endfor %}
     {%- for env in cookiecutter.tests.split(',') %}
     - TOXENV={{ env }}
     {%- endfor %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/vexor.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/vexor.yml
@@ -3,13 +3,16 @@
 
 language: python
 python:
-  {%- for env in cookiecutter.tests.split(',') if env not in ["flake8", "pylint", "behave"] %}
+  {%- for env in cookiecutter.tests.split(',') if env not in ["behave"] %}
   - "{{ env|replace('py27','2.7')|replace('py34','3.4')|replace('py35','3.5')|replace('py36','3.6') }}"
   {%- endfor %}
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
-    {%- for env in cookiecutter.tests.split(',') if env in ["flake8", "pylint", "behave"] %}
+    {%- for env in cookiecutter.checks.split(',') %}
+    - TOXENV={{ env }}
+    {%- endfor %}
+    {%- for env in cookiecutter.tests.split(',') if env in ["behave"] %}
     - TOXENV={{ env }}
     {%- endfor %}
     - TOXENV=$(echo $TRAVIS_PYTHON_VERSION | sed 's/^\([23]\)\.\([34567]\)/py\1\2/')


### PR DESCRIPTION
Splits up the "tests" in checks (linting, static code analysis) and actual tests (unit tests, functional tests).

This makes the graphical presentation of the builds nicer on GitLab, as well as improves its execution behavior (quick checks first, slower tests afterwards).