### PR TITLE
Upgrade Django skeleton

### DIFF
--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{18,19,110,111}
+envlist = django{111,20,21}
 skip_install = True
 skipsdist = True
 
@@ -7,12 +7,12 @@ skipsdist = True
 recreate = True
 deps =
     autopep8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
+    django20: Django>=2,<2.1
+    django21: Django>=2.1b1,<2.2
     django-environ
     flake8
+    pycodestyle<2.4
     pylint-django
 commands =
     # NOTE: platform independent solution for `mkdir -p {toxworkdir}/{envname}/_`
@@ -31,7 +31,7 @@ commands =
         -e 's/^import os/from os.path import abspath, dirname, join\nfrom environ import Env/' \
         -e 's/os.path.dirname(os.path.dirname(os.path.abspath(__file__)))/dirname(dirname(abspath(__file__)))/' \
         -e 's/os.path.join(/join(/g' \
-        -e "s/^SECRET_KEY = .*$/env = Env()\nEnv.read_env(join(BASE_DIR, '.env'))\n\nDEBUG = env.bool('DJANGO_DEBUG', default=True)\n\nSECRET_KEY = 'dummy-secret' if DEBUG else env('DJANGO_SECRET_KEY')/" \
+        -e "s/^SECRET_KEY = .*$/env = Env()  # pylint: disable=invalid-name\nEnv.read_env(join(BASE_DIR, '.env'))\n\nDEBUG = env.bool('DJANGO_DEBUG', default=True)\n\nSECRET_KEY = 'dummy-secret' if DEBUG else env('DJANGO_SECRET_KEY')/" \
         -e "s/^ALLOWED_HOSTS = .*$/ALLOWED_HOSTS = \[\] if DEBUG else \[\n    'example.com',\n]/" \
         -e "s#^STATIC_URL = .*$#STATIC_ROOT = join(BASE_DIR, 'static')\nSTATIC_URL = '/static/'#" \
         -e '/^DEBUG = True$/d' \
@@ -54,6 +54,6 @@ commands =
     # TODO: Add Django default templates in application app (base, 400, 403, 440, 500)
     autopep8 --in-place {toxworkdir}/{envname}/_/application/settings.py
     flake8 {toxworkdir}/{envname}/_/ --max-line-length=100
-    pylint {toxworkdir}/{envname}/_/application --load-plugins=pylint_django --good-names=application,env
+    pylint {toxworkdir}/{envname}/_/application --load-plugins=pylint_django
 whitelist_externals =
     sed

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -15,8 +15,8 @@ def shell(command, capture=False):
             stdout = check_output(command, shell=True, stderr=STDOUT,
                                   universal_newlines=True)
             return str(stdout)
-        else:
-            check_call(command, shell=True)
+
+        return check_call(command, shell=True)
     except CalledProcessError as err:
         LOG.error('Project generation failed.')
         sys.exit(err.returncode)

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
@@ -6,7 +6,7 @@ from environ import Env
 
 BASE_DIR = dirname(dirname(abspath(__file__)))
 
-env = Env()
+env = Env()  # pylint: disable=invalid-name
 Env.read_env(join(BASE_DIR, '.env'))
 
 DEBUG = env.bool('DJANGO_DEBUG', default=True)

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/urls.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/urls.py
@@ -1,21 +1,21 @@
 """application URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
+    https://docs.djangoproject.com/en/2.1/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/wsgi.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/wsgi.py
@@ -4,13 +4,12 @@ WSGI config for application project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/
 """
-
 import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "application.settings")
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'application.settings')
 
 application = get_wsgi_application()

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/manage.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "application.settings")
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'application.settings')
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
This skeleton upgrade for Django further pushes Python 3. Django version 1.11 LTS is the only [version officially supported](https://www.djangoproject.com/download/#supported-versions) by the Django project that still runs on Python 2 (officially).

- The generated code for Django 1.11 is still identical, with a single exeception: The `urls` module, which uses a `path` function instead of `url` since Django 2.0.
- The pylint-django plugin for Pylint now recognizes Django-specific small-caps names again. As `env` is not Django-specific we need to ignore that explicitly in the `settings`.
- `pep8` is now called `pycodestyle` (on [request of Guido van Rossum](https://github.com/PyCQA/pycodestyle/issues/466) in 2016), and unfortunately version 2.4 is incompatible with the latest `flake8` but nonetheless gets installed for some reason. We need to specify that in the `tox.ini` of the generator.
