### PR TITLE
Upgrade Python in CI config and tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,9 +29,9 @@ py37:
   stage: test
   script: tox -e py37
 
-pypy:
+pypy3:
   stage: test
-  script: tox -e pypy
+  script: tox -e pypy3
 
 behave:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,6 @@ pylint:
   stage: check
   script: tox -e pylint
 
-py27:
-  stage: test
-  script: tox -e py27
-
-py34:
-  stage: test
-  script: tox -e py34
-
 py35:
   stage: test
   script: tox -e py35
@@ -32,6 +24,10 @@ py35:
 py36:
   stage: test
   script: tox -e py36
+
+py37:
+  stage: test
+  script: tox -e py37
 
 pypy:
   stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - pypy
+  - pypy3
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@
 # Visit the docs at https://docs.travis-ci.com/
 
 language: python
-
-matrix:
-  include:
-    - { python: 3.5 }
-    - { python: 3.6 }
-    - { python: 3.7, dist: xenial, sudo: true }
-    - { python: pypy3 }
+python:
+  - 3.5
+  - 3.6
+  - pypy3
 
 stages:
   - lint
@@ -18,6 +15,7 @@ jobs:
   include:
     - { stage: lint, python: 3.6, env: TOXENV=flake8 }
     - { stage: lint, python: 3.6, env: TOXENV=pylint }
+    - { stage: test, python: 3.7, dist: xenial, sudo: true }
     - { stage: test, python: 3.6, env: TOXENV=behave }
 
 install: pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,23 @@
 # Visit the docs at https://docs.travis-ci.com/
 
 language: python
-python:
-  - 3.5
-  - 3.6
-  - 3.7
-  - pypy3
 
 matrix:
   include:
-    - { python: 3.6, env: TOXENV=flake8 }
-    - { python: 3.6, env: TOXENV=pylint }
-    - { python: 3.6, env: TOXENV=behave }
+    - { python: 3.5 }
+    - { python: 3.6 }
+    - { python: 3.7, dist: xenial, sudo: true }
+    - { python: pypy3 }
+
+stages:
+  - lint
+  - test
+
+jobs:
+  include:
+    - { stage: lint, python: 3.6, env: TOXENV=flake8 }
+    - { stage: lint, python: 3.6, env: TOXENV=pylint }
+    - { stage: test, python: 3.6, env: TOXENV=behave }
 
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,16 @@
 
 language: python
 python:
-  - 2.7
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - pypy
 
 matrix:
   include:
-    - { python: 3.5, env: TOXENV=flake8 }
-    - { python: 3.5, env: TOXENV=pylint }
-    - { python: 3.5, env: TOXENV=behave }
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=pylint }
+    - { python: 3.6, env: TOXENV=behave }
 
 install: pip install tox-travis
 script: tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ identified issues with additional commits:
 
 .. code-block:: bash
 
-    tox -e flake8,pylint,py35,py27
+    tox -e flake8,pylint,py36,py37
 
 Tests that require Docker must be run locally on your developer machine,
 because not all CI servers allow running Docker (inside Docker) on their

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -14,8 +14,8 @@
       command: tox -e py36
     - name: py37
       command: tox -e py37
-    - name: pypy
-      command: tox -e pypy
+    - name: pypy3
+      command: tox -e pypy3
     - name: behave
       command: tox -e behave
 

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -8,14 +8,12 @@
       command: tox -e flake8
     - name: pylint
       command: tox -e pylint
-    - name: py27
-      command: tox -e py27
-    - name: py34
-      command: tox -e py34
     - name: py35
       command: tox -e py35
     - name: py36
       command: tox -e py36
+    - name: py37
+      command: tox -e py37
     - name: pypy
       command: tox -e pypy
     - name: behave

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -40,7 +40,7 @@
         "MySQL/MariaDB"
     ],
     "checks": "flake8",
-    "tests": "py27,py35",
+    "tests": "py36,py37",
     "monitoring": [
         "(none)",
         "Datadog",

--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -9,7 +9,7 @@ deps =
     autopep8
     django111: Django>=1.11,<2
     django20: Django>=2,<2.1
-    django21: Django>=2.1b1,<2.2
+    django21: Django>=2.1,<2.2
     django-environ
     flake8
     pycodestyle<2.4

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,16 +3,15 @@
 
 language: python
 python:
-  - 3.5
+  - 3.6
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
     - TOXENV=flake8
     - TOXENV=pylint
-    - TOXENV=py27
-    - TOXENV=py34
     - TOXENV=py35
     - TOXENV=py36
+    - TOXENV=py37
     - TOXENV=pypy
     - TOXENV=behave
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -12,7 +12,7 @@ env:
     - TOXENV=py35
     - TOXENV=py36
     - TOXENV=py37
-    - TOXENV=pypy
+    - TOXENV=pypy3
     - TOXENV=behave
 
 build:

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -57,4 +57,5 @@ Examples:
 .. code-block:: bash
 
     $ tox -e behave -- --format=pretty
+    $ tox -e behave -- --tags=-docker
     $ tox -e flake8 -- --help

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -4,7 +4,7 @@ from . import verify_file_matches_repo_root
 
 
 # pylint: disable=too-few-public-methods
-class TestCISetup(object):
+class TestCISetup:
     """
     Tests for verifying generated CI setups of this cookiecutter,
     executed several times with different values (test scenarios).

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -17,7 +17,7 @@ class TestCISetup(object):
             'ci_service': 'bitbucket-pipelines.yml',
             'ci_testcommand': '          - tox',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('codeship', {
             'project_slug': 'myproject',
@@ -26,7 +26,7 @@ class TestCISetup(object):
             'ci_service': 'codeship-steps.yml',
             'ci_testcommand': '  service: app',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('gitlab', {
             'project_slug': 'myproject',
@@ -35,7 +35,7 @@ class TestCISetup(object):
             'ci_service': '.gitlab-ci.yml',
             'ci_testcommand': '  script: tox -e py36',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('shippable', {
             'project_slug': 'myproject',
@@ -44,7 +44,7 @@ class TestCISetup(object):
             'ci_service': 'shippable.yml',
             'ci_testcommand': '    - tox',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('travis', {
             'project_slug': 'myproject',
@@ -53,7 +53,7 @@ class TestCISetup(object):
             'ci_service': '.travis.yml',
             'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('vexor', {
             'project_slug': 'myproject',
@@ -62,7 +62,7 @@ class TestCISetup(object):
             'ci_service': 'vexor.yml',
             'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
     ]
 

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -17,7 +17,7 @@ class TestCISetup:
             'ci_service': 'bitbucket-pipelines.yml',
             'ci_testcommand': '          - tox',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('codeship', {
             'project_slug': 'myproject',
@@ -26,7 +26,7 @@ class TestCISetup:
             'ci_service': 'codeship-steps.yml',
             'ci_testcommand': '  service: app',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('gitlab', {
             'project_slug': 'myproject',
@@ -35,7 +35,7 @@ class TestCISetup:
             'ci_service': '.gitlab-ci.yml',
             'ci_testcommand': '  script: tox -e py36',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('shippable', {
             'project_slug': 'myproject',
@@ -44,7 +44,7 @@ class TestCISetup:
             'ci_service': 'shippable.yml',
             'ci_testcommand': '    - tox',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('travis', {
             'project_slug': 'myproject',
@@ -53,7 +53,7 @@ class TestCISetup:
             'ci_service': '.travis.yml',
             'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('vexor', {
             'project_slug': 'myproject',
@@ -62,7 +62,7 @@ class TestCISetup:
             'ci_service': 'vexor.yml',
             'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
     ]
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -41,7 +41,7 @@ class TestDatabase(object):
             },
             'required_packages': [
                 'django-environ',
-                'psycopg2',
+                'psycopg2-binary',
             ],
         }),
         ('MySQL/MariaDB', {

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -6,7 +6,7 @@ from . import verify_required_settings
 
 
 # pylint: disable=too-few-public-methods
-class TestDatabase(object):
+class TestDatabase:
     """
     Tests for verifying database configuration in generated projects.
     """

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -6,7 +6,7 @@ from . import verify_file_matches_repo_root
 
 
 # pylint: disable=too-few-public-methods
-class TestFramework(object):
+class TestFramework:
     """
     Tests for verifying generated projects using specific Web frameworks.
     """

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -43,7 +43,7 @@ class TestFramework:
                 ]),
             ],
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('flask', {
             'project_slug': 'flask-project',
@@ -77,7 +77,7 @@ class TestFramework:
                 ]),
             ],
             'checks': 'flake8,pylint',
-            'tests': 'py35,py36,py37,pypy,behave',
+            'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('symfony', {
             'project_slug': 'symfony-project',

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -43,7 +43,7 @@ class TestFramework(object):
                 ]),
             ],
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('flask', {
             'project_slug': 'flask-project',
@@ -77,7 +77,7 @@ class TestFramework(object):
                 ]),
             ],
             'checks': 'flake8,pylint',
-            'tests': 'py27,py34,py35,py36,pypy,behave',
+            'tests': 'py35,py36,py37,pypy,behave',
         }),
         ('symfony', {
             'project_slug': 'symfony-project',

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -6,7 +6,7 @@ from . import verify_required_settings
 
 
 # pylint: disable=too-few-public-methods
-class TestMonitoring(object):
+class TestMonitoring:
     """
     Tests for verifying monitoring configuration in generated projects.
     """

--- a/tests/unit/test_repos.py
+++ b/tests/unit/test_repos.py
@@ -3,7 +3,7 @@ from . import pytest_generate_tests  # noqa, pylint: disable=unused-import
 
 
 # pylint: disable=too-few-public-methods
-class TestRepos(object):
+class TestRepos:
     """
     Tests for verifying generated local Git repository and Docker registry
     setup, executed several times with different values (test scenarios).

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pylint,py27,py34,py35,py36,pypy,behave
+envlist = flake8,pylint,py27,py34,py35,py36,py37,pypy,pypy3,behave
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     git+https://github.com/behave/behave
     requests
 passenv = HOME
-commands = behave {posargs:--tags=-docker}
+commands = behave {posargs:--tags=-php}
 
 [testenv:clean]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pylint,py35,py36,py37,pypy,pypy3,behave
+envlist = flake8,pylint,py35,py36,py37,pypy3,behave
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pylint,py27,py34,py35,py36,py37,pypy,pypy3,behave
+envlist = flake8,pylint,py35,py36,py37,pypy,pypy3,behave
 skipsdist = true
 
 [testenv]

--- a/vexor.yml
+++ b/vexor.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy"
+  - "pypy3"
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'

--- a/vexor.yml
+++ b/vexor.yml
@@ -3,10 +3,9 @@
 
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
 
 env:

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -11,7 +11,7 @@ To start developing on this project simply bring up the Docker setup:
 .. code-block:: bash
 {% if cookiecutter.framework == 'Django' %}
     docker-compose up --build -d
-    docker-compose run application python manage.py migrate
+    docker-compose exec application python manage.py migrate
     docker-compose logs -f
 {% elif cookiecutter.framework in ['Symfony', 'TYPO3'] %}
     composer install
@@ -19,10 +19,8 @@ To start developing on this project simply bring up the Docker setup:
 {% else %}
     docker-compose up --build
 {% endif %}
-Open your web browser at http://localhost (on a Linux host) or
-http://<docker-machine-ip-address> (on OS X and Windows), usually the
-IP address of the VirtualBox VM called ``default``, to see the application
-you're developing.  Log output will be displayed in the terminal, as usual.
+Open your web browser at http://localhost to see the application you're
+developing.  Log output will be displayed in the terminal, as usual.
 
 Working with Docker
 ^^^^^^^^^^^^^^^^^^^

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -3,15 +3,15 @@
 
 language: python
 python:
-  {%- for env in '2.7,3.4,3.5,3.6,pypy'.split(',') %}
+  {%- for env in '3.5,3.6,3.7,pypy'.split(',') %}
   - {{ env }}
   {%- endfor %}
 
 matrix:
   include:
-    - { python: 3.5, env: TOXENV=flake8 }
-    - { python: 3.5, env: TOXENV=pylint }
-    - { python: 3.5, env: TOXENV=behave }
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=pylint }
+    - { python: 3.6, env: TOXENV=behave }
 
 install: pip install tox-travis
 script: tox

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -2,13 +2,10 @@
 # Visit the docs at https://docs.travis-ci.com/
 
 language: python
-
-matrix:
-  include:
-    {%- for env in cookiecutter.tests.split(",") if env not in ["behave"] %}
-    - { python: {{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}
-        {%- if env == 'py37' %}, dist: xenial, sudo: true{% endif %} }
-    {%- endfor %}
+python:
+  {%- for env in cookiecutter.tests.split(",") if env not in ["behave", "py37"] %}
+  - {{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}
+  {%- endfor %}
 
 stages:
   - lint
@@ -19,6 +16,9 @@ jobs:
     {%- for env in cookiecutter.checks.split(",") %}
     - { stage: lint, python: 3.6, env: TOXENV={{ env }} }
     {%- endfor %}
+    {%- if "py37" in cookiecutter.tests.split(",") %}
+    - { stage: test, python: 3.7, dist: xenial, sudo: true }
+    {%- endif %}
     {%- if "behave" in cookiecutter.tests.split(",") %}
     - { stage: test, python: 3.6, env: TOXENV=behave }
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-  {%- for env in '3.5,3.6,3.7,pypy'.split(',') %}
+  {%- for env in '3.5,3.6,3.7,pypy3'.split(',') %}
   - {{ env }}
   {%- endfor %}
 

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -2,16 +2,26 @@
 # Visit the docs at https://docs.travis-ci.com/
 
 language: python
-python:
-  {%- for env in '3.5,3.6,3.7,pypy3'.split(',') %}
-  - {{ env }}
-  {%- endfor %}
 
 matrix:
   include:
-    - { python: 3.6, env: TOXENV=flake8 }
-    - { python: 3.6, env: TOXENV=pylint }
-    - { python: 3.6, env: TOXENV=behave }
+    {%- for env in cookiecutter.tests.split(",") if env not in ["behave"] %}
+    - { python: {{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}
+        {%- if env == 'py37' %}, dist: xenial, sudo: true{% endif %} }
+    {%- endfor %}
+
+stages:
+  - lint
+  - test
+
+jobs:
+  include:
+    {%- for env in cookiecutter.checks.split(",") %}
+    - { stage: lint, python: 3.6, env: TOXENV={{ env }} }
+    {%- endfor %}
+    {%- if "behave" in cookiecutter.tests.split(",") %}
+    - { stage: test, python: 3.6, env: TOXENV=behave }
+    {%- endif %}
 
 install: pip install tox-travis
 script: tox

--- a/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-  - 3.5
+  - 3.6
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'

--- a/{{cookiecutter.project_slug}}/_/ci-services/vexor.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/vexor.yml
@@ -4,7 +4,7 @@
 language: python
 python:
   {%- for env in cookiecutter.tests.split(',') if env not in ["behave"] %}
-  - "{{ env|replace('py27','2.7')|replace('py34','3.4')|replace('py35','3.5')|replace('py36','3.6') }}"
+  - "{{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}"
   {%- endfor %}
 
 env:

--- a/{{cookiecutter.project_slug}}/_/deployment/python/config/application/Dockerfile
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/config/application/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.7
 WORKDIR /opt/{{ cookiecutter.project_slug }}
 COPY requirements.txt requirements.txt
 RUN pip install uwsgi -r requirements.txt

--- a/{{cookiecutter.project_slug}}/_/deployment/python/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/docker-compose.yml
@@ -1,10 +1,7 @@
 # Painless development and deployment with Docker.
 # Visit the docs at https://docs.docker.com/compose/
 
-version: "3"
-
-volumes:
-  database_data: {}
+version: "2"
 
 services:
   webserver:
@@ -47,4 +44,9 @@ services:
     #   - "3306:3306"
     volumes:
       - database_data:/var/lib/mysql/data
+{%- endif %}
+{%- if cookiecutter.database in ['Postgres', 'MySQL/MariaDB'] %}
+
+volumes:
+  database_data:
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/deployment/python/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/docker-compose.yml
@@ -1,7 +1,7 @@
 # Painless development and deployment with Docker.
 # Visit the docs at https://docs.docker.com/compose/
 
-version: "2"
+version: "3"
 
 volumes:
   database_data: {}
@@ -30,10 +30,6 @@ services:
   database:
     image: postgres
     # Make database accessible on localhost during development
-    # # NOTE: on OS X and Windows, if you use docker-machine and VirtualBox,
-    # # ----  you need to configure port forwarding in addition; see
-    # #     https://jihedamine.github.io/docker-liferay-virtualbox#setup-port-forwarding
-    # #     https://docs.docker.com/engine/installation/#/on-macos-and-windows
     # ports:
     #   - "5432:5432"
     volumes:
@@ -47,10 +43,6 @@ services:
       MYSQL_USER: mysql
       MYSQL_PASSWORD: mysql
     # Make database accessible on localhost during development
-    # # NOTE: on OS X and Windows, if you use docker-machine and VirtualBox,
-    # # ----  you need to configure port forwarding in addition; see
-    # #     https://jihedamine.github.io/docker-liferay-virtualbox#setup-port-forwarding
-    # #     https://docs.docker.com/engine/installation/#/on-macos-and-windows
     # ports:
     #   - "3306:3306"
     volumes:

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -1,6 +1,6 @@
-Django>=1.11,<2
+Django>=2,<2.1
 django-environ
-{% if cookiecutter.database == 'Postgres' %}psycopg2
+{% if cookiecutter.database == 'Postgres' %}psycopg2-binary
 {% elif cookiecutter.database == 'MySQL/MariaDB' %}mysqlclient
 {% endif -%}
 {% if cookiecutter.monitoring == 'Datadog' %}django-datadog

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2,<2.1
+Django>=2.1,<2.2
 django-environ
 {% if cookiecutter.database == 'Postgres' %}psycopg2-binary
 {% elif cookiecutter.database == 'MySQL/MariaDB' %}mysqlclient

--- a/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
@@ -57,4 +57,5 @@ Examples:
 .. code-block:: bash
 
     $ tox -e behave -- --format=pretty
+    $ tox -e behave -- --tags=-docker
     $ tox -e flake8 -- --help


### PR DESCRIPTION
We drop Python 2.7 and 3.4, and replace PyPy by PyPy3 in tests and CI.

Use latest release of Django (2.1, compatible 2.0), which is incompatible with 1.11 in Django's `urls` module.