### PR TITLE
Add steps to Bitbucket Pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,20 @@
 
 language: python
 python:
-  - 3.5
-  - 3.6
-  - pypy3
+- 3.5
+- 3.6
+- pypy3
 
 stages:
-  - lint
-  - test
+- lint
+- test
 
 jobs:
   include:
-    - { stage: lint, python: 3.6, env: TOXENV=flake8 }
-    - { stage: lint, python: 3.6, env: TOXENV=pylint }
-    - { stage: test, python: 3.7, dist: xenial, sudo: true }
-    - { stage: test, python: 3.6, env: TOXENV=behave }
+  - { stage: lint, python: 3.6, env: TOXENV=flake8 }
+  - { stage: lint, python: 3.6, env: TOXENV=pylint }
+  - { stage: test, python: 3.7, dist: xenial, sudo: true }
+  - { stage: test, python: 3.6, env: TOXENV=behave }
 
 install: pip install tox-travis
 script: tox
-
-before_cache:
-  - rm -rf $HOME/.cache/pip/log
-cache:
-  directories:
-    - $HOME/.cache/pip

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -2,8 +2,34 @@
 # Visit the docs at https://confluence.atlassian.com/x/VYk8Lw
 
 image: painless/tox:multi
+
 pipelines:
   default:
-    - step:
-        script:
-          - tox
+  - step:
+      name: Flake8
+      script:
+      - tox -e flake8
+  - step:
+      name: Pylint
+      script:
+      - tox -e pylint
+  - step:
+      name: Python 3.5
+      script:
+      - tox -e py35
+  - step:
+      name: Python 3.6
+      script:
+      - tox -e py36
+  - step:
+      name: Python 3.7
+      script:
+      - tox -e py37
+  - step:
+      name: PyPy 3
+      script:
+      - tox -e pypy3
+  - step:
+      name: Behave
+      script:
+      - tox -e behave

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -7,4 +7,4 @@ services:
   app:
     image: painless/tox:multi
     volumes:
-      - .:/app
+    - .:/app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -4,20 +4,20 @@
 - type: parallel
   service: app
   steps:
-    - name: flake8
-      command: tox -e flake8
-    - name: pylint
-      command: tox -e pylint
-    - name: py35
-      command: tox -e py35
-    - name: py36
-      command: tox -e py36
-    - name: py37
-      command: tox -e py37
-    - name: pypy3
-      command: tox -e pypy3
-    - name: behave
-      command: tox -e behave
+  - name: flake8
+    command: tox -e flake8
+  - name: pylint
+    command: tox -e pylint
+  - name: py35
+    command: tox -e py35
+  - name: py36
+    command: tox -e py36
+  - name: py37
+    command: tox -e py37
+  - name: pypy3
+    command: tox -e pypy3
+  - name: behave
+    command: tox -e behave
 
 - name: deploy_staging
   service: app

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,24 +3,20 @@
 
 language: python
 python:
-  - 3.6
+- 3.7
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
-    - TOXENV=flake8
-    - TOXENV=pylint
-    - TOXENV=py35
-    - TOXENV=py36
-    - TOXENV=py37
-    - TOXENV=pypy3
-    - TOXENV=behave
+  - TOXENV=flake8
+  - TOXENV=pylint
+  - TOXENV=py35
+  - TOXENV=py36
+  - TOXENV=py37
+  - TOXENV=pypy3
+  - TOXENV=behave
 
 build:
-  cache: true
-  cache_dir_list:
-    - $HOME/.cache/pip
   ci:
-    - rm -rf $HOME/.cache/pip/log
-    - pip install tox
-    - tox
-    - mv -v tests/reports/* shippable/testresults/ || true
+  - pip install tox
+  - tox
+  - mv -v tests/reports/* shippable/testresults/ || true

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,6 +1,7 @@
 """Common helper functions and values for running tests with py.test."""
-from filecmp import cmp as compare_files
-from os.path import dirname, pathsep
+from difflib import context_diff
+from os.path import dirname
+import os.path
 from py._path.local import LocalPath
 
 REPO_ROOT_PATH = LocalPath(dirname(dirname(dirname(__file__))))
@@ -87,6 +88,11 @@ def verify_file_matches_repo_root(result, *file):
     """
     mother_file = REPO_ROOT_PATH.join(*file).strpath
     generated_file = result.project.join(*file).strpath
-    assert compare_files(mother_file, generated_file), \
-        "Mother project '{}' not matching template.\n {} != {}".format(
-            pathsep.join(file), mother_file, generated_file)
+    with open(mother_file) as mother, open(generated_file) as generated:
+        diff = ''.join(context_diff(mother.readlines(),
+                                    generated.readlines(),
+                                    fromfile=mother_file,
+                                    tofile=generated_file))
+    assert not diff, \
+        "Mother project '{}' not matching template.\n{}".format(
+            os.path.join(*file), diff)

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -15,7 +15,7 @@ class TestCISetup:
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'bitbucket-pipelines.yml',
-            'ci_testcommand': '          - tox',
+            'ci_testcommand': '      - tox -e py37',
             'checks': 'flake8,pylint',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
@@ -33,7 +33,7 @@ class TestCISetup:
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitLab.com',
             'ci_service': '.gitlab-ci.yml',
-            'ci_testcommand': '  script: tox -e py36',
+            'ci_testcommand': '  script: tox -e py37',
             'checks': 'flake8,pylint',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
@@ -42,7 +42,7 @@ class TestCISetup:
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'shippable.yml',
-            'ci_testcommand': '    - tox',
+            'ci_testcommand': '  - tox',
             'checks': 'flake8,pylint',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
@@ -89,7 +89,8 @@ class TestCISetup:
         assert result.project.join('README.rst').isfile()
 
         ci_service_conf = result.project.join(ci_service).readlines(cr=False)
-        assert ci_testcommand in ci_service_conf
+        assert ci_testcommand in ci_service_conf, \
+            "Test command not found in CI config: '%s'" % ci_testcommand
 
         codeship_services = result.project.join('codeship-services.yml')
         assert (ci_service == 'codeship-steps.yml' and

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -3,31 +3,25 @@
 
 language: python
 python:
-  {%- for env in cookiecutter.tests.split(",") if env not in ["behave", "py37"] %}
-  - {{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}
-  {%- endfor %}
+{%- for env in cookiecutter.tests.split(",") if env not in ["behave", "py37"] %}
+- {{ env|replace('py35','3.5')|replace('py36','3.6')|replace('py37','3.7') }}
+{%- endfor %}
 
 stages:
-  - lint
-  - test
+- lint
+- test
 
 jobs:
   include:
-    {%- for env in cookiecutter.checks.split(",") %}
-    - { stage: lint, python: 3.6, env: TOXENV={{ env }} }
-    {%- endfor %}
-    {%- if "py37" in cookiecutter.tests.split(",") %}
-    - { stage: test, python: 3.7, dist: xenial, sudo: true }
-    {%- endif %}
-    {%- if "behave" in cookiecutter.tests.split(",") %}
-    - { stage: test, python: 3.6, env: TOXENV=behave }
-    {%- endif %}
+  {%- for env in cookiecutter.checks.split(",") %}
+  - { stage: lint, python: 3.6, env: TOXENV={{ env }} }
+  {%- endfor %}
+  {%- if "py37" in cookiecutter.tests.split(",") %}
+  - { stage: test, python: 3.7, dist: xenial, sudo: true }
+  {%- endif %}
+  {%- if "behave" in cookiecutter.tests.split(",") %}
+  - { stage: test, python: 3.6, env: TOXENV=behave }
+  {%- endif %}
 
 install: pip install tox-travis
 script: tox
-
-before_cache:
-  - rm -rf $HOME/.cache/pip/log
-cache:
-  directories:
-    - $HOME/.cache/pip

--- a/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
@@ -2,8 +2,18 @@
 # Visit the docs at https://confluence.atlassian.com/x/VYk8Lw
 
 image: painless/tox:multi
+
 pipelines:
   default:
-    - step:
-        script:
-          - tox
+  {%- for env in cookiecutter.checks.split(",") %}
+  - step:
+      name: {{ env|capitalize }}
+      script:
+      - tox -e {{ env }}
+  {%- endfor %}
+  {%- for env in cookiecutter.tests.split(",") %}
+  - step:
+      name: {{ env|replace('py35','Python 3.5')|replace('py36','Python 3.6')|replace('py37','Python 3.7')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
+      script:
+      - tox -e {{ env }}
+  {%- endfor %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/codeship-services.yml
@@ -7,4 +7,4 @@ services:
   app:
     image: painless/tox:multi
     volumes:
-      - .:/app
+    - .:/app

--- a/{{cookiecutter.project_slug}}/_/ci-services/codeship-steps.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/codeship-steps.yml
@@ -4,14 +4,14 @@
 - type: parallel
   service: app
   steps:
-    {%- for env in cookiecutter.checks.split(',') %}
-    - name: {{ env }}
-      command: tox -e {{ env }}
-    {%- endfor %}
-    {%- for env in cookiecutter.tests.split(',') %}
-    - name: {{ env }}
-      command: tox -e {{ env }}
-    {%- endfor %}
+  {%- for env in cookiecutter.checks.split(',') %}
+  - name: {{ env }}
+    command: tox -e {{ env }}
+  {%- endfor %}
+  {%- for env in cookiecutter.tests.split(',') %}
+  - name: {{ env }}
+    command: tox -e {{ env }}
+  {%- endfor %}
 
 - name: deploy_staging
   service: app

--- a/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
@@ -3,23 +3,19 @@
 
 language: python
 python:
-  - 3.6
+- 3.7
 
 env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
-    {%- for env in cookiecutter.checks.split(',') %}
-    - TOXENV={{ env }}
-    {%- endfor %}
-    {%- for env in cookiecutter.tests.split(',') %}
-    - TOXENV={{ env }}
-    {%- endfor %}
+  {%- for env in cookiecutter.checks.split(',') %}
+  - TOXENV={{ env }}
+  {%- endfor %}
+  {%- for env in cookiecutter.tests.split(',') %}
+  - TOXENV={{ env }}
+  {%- endfor %}
 
 build:
-  cache: true
-  cache_dir_list:
-    - $HOME/.cache/pip
   ci:
-    - rm -rf $HOME/.cache/pip/log
-    - pip install tox
-    - tox
-    - mv -v tests/reports/* shippable/testresults/ || true
+  - pip install tox
+  - tox
+  - mv -v tests/reports/* shippable/testresults/ || true


### PR DESCRIPTION
- Adds steps to Bitbucket Pipelines (nicer display in Pipelines)
- Makes use of condensed YAML formatting (as generated by travis CLI client)
- Removes `pip` caching from Travis and Shippable (readability)