### PR TITLE
Replace code health badge, run Bandit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,10 @@ pylint:
   stage: check
   script: tox -e pylint
 
+bandit:
+  stage: check
+  script: tox -e bandit
+
 py35:
   stage: test
   script: tox -e py35

--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,5 +1,0 @@
-ignore-patterns:
-  - (^|/).*/_/frameworks(/|$)
-python-targets:
-  - 2
-  - 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
   include:
   - { stage: lint, python: 3.6, env: TOXENV=flake8 }
   - { stage: lint, python: 3.6, env: TOXENV=pylint }
+  - { stage: lint, python: 3.6, env: TOXENV=bandit }
   - { stage: test, python: 3.7, dist: xenial, sudo: true }
   - { stage: test, python: 3.6, env: TOXENV=behave }
 

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ A cookiecutter for projects with continuous delivery baked in.
 .. |about| image:: https://img.shields.io/badge/About-Painless_Continuous_Delivery-44a0dd.svg
    :target: https://slides.com/bittner/djangocon2017-painless-continuous-delivery/
    :alt: Elevator pitch
-.. |health| image:: https://landscape.io/github/painless-software/painless-continuous-delivery/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/painless-software/painless-continuous-delivery/master
+.. |health| image:: https://img.shields.io/codacy/grade/7aade15697ed4ad39758553efcd31c77/master.svg
+   :target: https://www.codacy.com/app/painless/painless-continuous-delivery
    :alt: Code health
 
 Supported Technologies and Services

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -14,6 +14,10 @@ pipelines:
         name: Pylint
         script:
         - tox -e pylint
+    - step:
+        name: Bandit
+        script:
+        - tox -e bandit
 
   - parallel: &tests
     - step:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -9,6 +9,8 @@
     command: tox -e flake8
   - name: Pylint
     command: tox -e pylint
+  - name: Bandit
+    command: tox -e bandit
 
 - name: Tests
   type: parallel

--- a/shippable.yml
+++ b/shippable.yml
@@ -9,6 +9,7 @@ env:
   matrix:  # $ tox -l | xargs -I ARG echo '    - TOXENV=ARG'
   - TOXENV=flake8
   - TOXENV=pylint
+  - TOXENV=bandit
   - TOXENV=py35
   - TOXENV=py36
   - TOXENV=py37

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -16,7 +16,7 @@ class TestCISetup:
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'bitbucket-pipelines.yml',
             'ci_testcommand': '        - tox -e py37',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('codeship', {
@@ -25,7 +25,7 @@ class TestCISetup:
             'vcs_platform': 'GitHub.com',
             'ci_service': 'codeship-steps.yml',
             'ci_testcommand': '  service: app',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('gitlab', {
@@ -34,7 +34,7 @@ class TestCISetup:
             'vcs_platform': 'GitLab.com',
             'ci_service': '.gitlab-ci.yml',
             'ci_testcommand': '  script: tox -e py37',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('shippable', {
@@ -43,7 +43,7 @@ class TestCISetup:
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'shippable.yml',
             'ci_testcommand': '  - tox',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('travis', {
@@ -52,7 +52,7 @@ class TestCISetup:
             'vcs_platform': 'GitHub.com',
             'ci_service': '.travis.yml',
             'ci_testcommand': 'script: tox',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
         ('vexor', {
@@ -61,7 +61,7 @@ class TestCISetup:
             'vcs_platform': 'GitHub.com',
             'ci_service': 'vexor.yml',
             'ci_testcommand': 'script: tox',
-            'checks': 'flake8,pylint',
+            'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
         }),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pylint,py35,py36,py37,pypy3,behave
+envlist = flake8,pylint,bandit,py35,py36,py37,pypy3,behave
 skipsdist = true
 
 [testenv]
@@ -19,6 +19,10 @@ deps =
 commands =
     pylint --rcfile tox.ini {posargs:tests hooks/post_gen_project.py}
 
+[testenv:bandit]
+deps = bandit
+commands = bandit -r --ini tox.ini
+
 [testenv:behave]
 deps =
     {[testenv]deps}
@@ -37,6 +41,10 @@ commands =
     find . -type d -name __pycache__ -delete
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
 
+[bandit]
+targets = behave_django
+exclude = .cache,.git,.tox,build,dist,docs,tests,./*/_/frameworks/
+
 [behave]
 # default_format = progress
 default_tags = -@not_implemented -@xfail
@@ -47,7 +55,7 @@ show_skipped = no
 summary = no
 
 [flake8]
-exclude = .cache,.git,.tox,build,./*/_/frameworks/
+exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
 
 [MASTER]  # Pylint
 disable = duplicate-code

--- a/vexor.yml
+++ b/vexor.yml
@@ -12,6 +12,7 @@ env:
   matrix:  # $ tox -l | xargs -I ARG echo '  - TOXENV=ARG'
   - TOXENV=flake8
   - TOXENV=pylint
+  - TOXENV=bandit
   - TOXENV=behave
   - TOXENV=$(echo $TRAVIS_PYTHON_VERSION | sed 's/^\([23]\)\.\([34567]\)/py\1\2/')
 


### PR DESCRIPTION
- Run Bandit, the PyCQA security linter
- Use Codacy (instead of Landscape) for static code analysis