### PR TITLE
Allow bandit to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ pylint:
 bandit:
   stage: check
   script: tox -e bandit
+  allow_failure: true
 
 py35:
   stage: test

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,8 +15,10 @@ env:
   - TOXENV=py37
   - TOXENV=pypy3
   - TOXENV=behave
+
+matrix:
   allow_failures:
-  - TOXENV=bandit
+  - env: TOXENV=bandit
 
 build:
   ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,6 +15,8 @@ env:
   - TOXENV=py37
   - TOXENV=pypy3
   - TOXENV=behave
+  allow_failures:
+  - TOXENV=bandit
 
 build:
   ci:

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},clean
+envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Bandit notifies us about security issues, but we don't want it to stop the pipeline (for now).
Also on GitLab and Shippable.