### PR TITLE
Prepare New Relic integration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -47,6 +47,7 @@
     "monitoring": [
         "(none)",
         "Datadog",
+        "NewRelic",
         "Sentry"
     ],
     "_copy_without_render": [

--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -63,7 +63,7 @@ commands =
         {toxworkdir}/{envname}/_/application/settings.py
     sed -i -z \
         -e "s/$/\nif DEBUG:\n    DEBUG_TOOLBAR_CONFIG = \{\n        'SHOW_TEMPLATE_CONTEXT': True,\n        'SHOW_TOOLBAR_CALLBACK': lambda request: True,\n    \}\n    MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']\n    INSTALLED_APPS += ['debug_toolbar']\n/" \
-        -e "s/$/\{%- if cookiecutter.monitoring == 'Datadog' %\}\n\nDATADOG_API_KEY = env('DATADOG_API_KEY', default=None)\nDATADOG_APP_KEY = env('DATADOG_APP_KEY', default=None)\nDATADOG_APP_NAME = env('DATADOG_APP_NAME', default=None)\n\{%- endif %\}\n/" \
+        -e "s/$/\{%- if cookiecutter.monitoring == 'Datadog' %\}\n\nDATADOG_API_KEY = env('DATADOG_API_KEY', default=None)\nDATADOG_APP_KEY = env('DATADOG_APP_KEY', default=None)\nDATADOG_APP_NAME = env('DATADOG_APP_NAME', default=None)\n\{%- elif cookiecutter.monitoring == 'NewRelic' %\}\n\nNEWRELIC_LICENSE_KEY = env('NEWRELIC_LICENSE_KEY', default=None)\n\nif NEWRELIC_LICENSE_KEY:\n    import newrelic.agent\n\n    newrelic.agent.initialize(join(BASE_DIR, 'newrelic.ini'))\n\{%- endif %\}\n/" \
         -e 's/\n\n\n\n"""\n\n/\n"""\n/g' \
         -e 's/\n\n\n/\n\n/g' \
         {toxworkdir}/{envname}/_/application/settings.py

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -27,6 +27,18 @@ class TestMonitoring:
                 'django-datadog',
             ],
         }),
+        ('NewRelic(django)', {
+            'project_slug': 'django-project',
+            'framework': 'Django',
+            'monitoring': 'NewRelic',
+            'required_settings': {
+                'NEWRELIC_LICENSE_KEY':
+                "env('NEWRELIC_LICENSE_KEY', default=None)",
+            },
+            'required_packages': [
+                'newrelic',
+            ],
+        }),
         ('Sentry(django)', {
             'project_slug': 'django-project',
             'framework': 'Django',

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
@@ -156,4 +156,12 @@ if DEBUG:
 DATADOG_API_KEY = env('DATADOG_API_KEY', default=None)
 DATADOG_APP_KEY = env('DATADOG_APP_KEY', default=None)
 DATADOG_APP_NAME = env('DATADOG_APP_NAME', default=None)
+{%- elif cookiecutter.monitoring == 'NewRelic' %}
+
+NEWRELIC_LICENSE_KEY = env('NEWRELIC_LICENSE_KEY', default=None)
+
+if NEWRELIC_LICENSE_KEY:
+    import newrelic.agent
+
+    newrelic.agent.initialize(join(BASE_DIR, 'newrelic.ini'))
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/base.in
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/base.in
@@ -1,9 +1,15 @@
 Django>=2.2,<3.0
 django-environ
 django-probes
-{% if cookiecutter.database == 'Postgres' %}psycopg2
-{% elif cookiecutter.database == 'MySQL/MariaDB' %}mysql-connector
+{% if cookiecutter.database == 'Postgres' -%}
+psycopg2
+{% elif cookiecutter.database == 'MySQL/MariaDB' -%}
+mysql-connector
 {% endif -%}
-{% if cookiecutter.monitoring == 'Datadog' %}django-datadog
-{% elif cookiecutter.monitoring == 'Sentry' %}sentry-sdk
+{% if cookiecutter.monitoring == 'Datadog' -%}
+django-datadog
+{% elif cookiecutter.monitoring == 'NewRelic' -%}
+newrelic
+{% elif cookiecutter.monitoring == 'Sentry' -%}
+sentry-sdk
 {% endif -%}

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
@@ -17,6 +17,8 @@ mysql-connector==2.2.9
 {% endif -%}
 {% if cookiecutter.monitoring == 'Datadog' -%}
 django-datadog==1.0.1
+{% elif cookiecutter.monitoring == 'NewRelic' -%}
+newrelic==4.20.0.120
 {% elif cookiecutter.monitoring == 'Sentry' -%}
 sentry-sdk==0.9.1
 certifi==2019.6.16        # via sentry-sdk


### PR DESCRIPTION
New Relic has a very traditional integration ([using a generated INI file](https://docs.newrelic.com/docs/agents/python-agent/installation/advanced-install-new-relic-python-agent)). This is not nice to integrate in Kubernetes or OpenShift (following the [12 factor app metodology](https://12factor.net/)).

We're preparing the integration here in a way that may be closer to where we want it to be, and try to communicate with New Relic support to maybe get the integration modernized.