### PR TITLE
Run linting and tests in MRs

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -18,10 +18,17 @@ stages:
 .check:
   stage: check
   image: docker.io/painless/tox
+  only:
+  - merge_requests
+  - master
 
 .test:
   stage: test
   image: docker.io/painless/tox
+  only:
+  - merge_requests
+  - master
+
 
 .build:
   stage: build


### PR DESCRIPTION
This fixes (as in "align with master") the pipeline behavior in GitLab MRs.