### PR TITLE
Create pod anti affinity rule

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application.yaml
@@ -144,3 +144,11 @@ objects:
               cpu: 200m
               memory: 64Mi
         restartPolicy: Always
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app: ${APP_NAME}
+                    component: ${COMPONENT}
+                topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
To ensure pods of the same deployment are never scheduled on the same
node.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>