### PR TITLE
Fix typo and failing step in GitLab pipeline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,16 @@
 [tox]
-envlist = flake8,pylint,bandit,py35,py36,py37,pypy3,behave
+envlist = flake8,pylint,bandit,py35,py36,py37,py38,pypy3,behave
 skipsdist = true
 
 [testenv]
+description = Unit tests
 deps =
     flake8
     pytest-cookies
 commands = pytest {posargs}
 
 [testenv:clean]
+description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
     py3clean {toxinidir}
@@ -17,10 +19,12 @@ whitelist_externals =
     rm
 
 [testenv:flake8]
+description = Static code analysis and code style
 deps = flake8
 commands = flake8 {posargs}
 
 [testenv:pylint]
+description = Check for errors and code smells
 deps =
     {[testenv]deps}
     pylint
@@ -28,10 +32,12 @@ commands =
     pylint --rcfile tox.ini {posargs:tests hooks/post_gen_project.py}
 
 [testenv:bandit]
+description = PyCQA security linter
 deps = bandit<1.6.0
 commands = bandit -r --ini tox.ini
 
 [testenv:behave]
+description = BDD acceptance test
 deps =
     {[testenv]deps}
     behave
@@ -40,6 +46,7 @@ passenv = HOME
 commands = behave {posargs:--tags=-php}
 
 [testenv:cookiecutter]
+description = Isolated cookiecutter runner
 deps = cookiecutter
 changedir = /tmp
 commands = cookiecutter {toxinidir} {posargs}
@@ -66,7 +73,6 @@ exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
 disable = duplicate-code
 min-similarity-lines = 5
 output-format = colorized
-reports = no
 
 [pytest]
 addopts =

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -50,16 +50,17 @@ stages:
     DATABASE_NAME: postgres{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
   before_script:
   - DJANGO_SECRET_KEY=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c50)
-  - POSTGRES_PASSWORD=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
+    POSTGRES_PASSWORD=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
+    true
   - kubectl -n ${TARGET} get secret ${APPLICATION_NAME} ||
     kubectl -n ${TARGET} create secret generic ${APPLICATION_NAME}
-    --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
     --from-literal=DJANGO_DATABASE_URL=postgres://{{ cookiecutter.project_slug.replace('-', '_') }}:${POSTGRES_PASSWORD}@${DATABASE_NAME}/{{ cookiecutter.project_slug.replace('-', '_') }}
+    --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
   - kubectl -n ${TARGET} get secret ${DATABASE_NAME} ||
     kubectl -n ${TARGET} create secret generic ${DATABASE_NAME}
-    --from-literal=POSTGRESQL_PASSWORD=${POSTGRES_PASSWORD}
-    --from-literal=POSTGRESQL_USER={{ cookiecutter.project_slug.replace('-', '_') }}
     --from-literal=POSTGRESQL_DATABASE={{ cookiecutter.project_slug.replace('-', '_') }}
+    --from-literal=POSTGRESQL_USER={{ cookiecutter.project_slug.replace('-', '_') }}
+    --from-literal=POSTGRESQL_PASSWORD=${POSTGRES_PASSWORD}
 
 .deploy:
   stage: deploy

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -63,7 +63,7 @@ stages:
 
 .deploy:
   stage: deploy
-  extends: generate-secrets
+  extends: .generate-secrets
   environment:
     url: "${KUBE_URL}/console/project/{{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/overview"
   image: docker.io/appuio/oc:v3.11


### PR DESCRIPTION
Fixes some issues introduced with PR #52:

- A typo in an `extends:` of the GitLab CI configuration made GitLab abort the execution
- A step in GitLab CI must always run a command returning a status
