### PR TITLE
Add suffix to route (not covered by kustomize edit)

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -75,6 +75,7 @@ stages:
   - pushd deployment/application/base &&
 {%- if cookiecutter.environment_strategy == 'shared' %}
     kustomize edit set namesuffix -- "-${CI_ENVIRONMENT_NAME}" &&
+    sed -Ez "s/(kind: Service.*name: application)/\1-${CI_ENVIRONMENT_NAME}/" -i route.yaml &&
 {%- endif %}
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd


### PR DESCRIPTION
`kustomize edit set namesuffix` only works for Kubernetes objects, hence the `route` object is not processed. We need to do this the "manual" way, using the good-old `sed -i`. Not elegant, but ...