### PR TITLE
Fix invalid YAML (GitLab CI configuration)

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -75,13 +75,16 @@ stages:
   - pushd deployment/application/base &&
 {%- if cookiecutter.environment_strategy == 'shared' %}
     kustomize edit set namesuffix -- "-${CI_ENVIRONMENT_NAME}" &&
-    sed -Ez "s/(kind. Service.*name. application)/\1-${CI_ENVIRONMENT_NAME}/" -i route.yaml &&
+    sed -Ez -i deployment.yaml -i route.yaml
+        -e "s/((secretRef|kind. Service).[^:]*name. application)/\1-${CI_ENVIRONMENT_NAME}/g" &&
 {%- endif %}
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd
 {%- if cookiecutter.environment_strategy == 'shared' %}
   - pushd deployment/database/base &&
     kustomize edit set namesuffix -- "-${CI_ENVIRONMENT_NAME}" &&
+    sed -Ez -i deployment.yaml
+        -e "s/(secretRef.[^:]*name. postgres)/\1-${CI_ENVIRONMENT_NAME}/g" &&
     popd
 {%- endif %}
   - kustomize build deployment/application/overlays/${CI_ENVIRONMENT_NAME} | kubeval --strict --ignore-missing-schemas

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -75,7 +75,7 @@ stages:
   - pushd deployment/application/base &&
 {%- if cookiecutter.environment_strategy == 'shared' %}
     kustomize edit set namesuffix -- "-${CI_ENVIRONMENT_NAME}" &&
-    sed -Ez "s/(kind: Service.*name: application)/\1-${CI_ENVIRONMENT_NAME}/" -i route.yaml &&
+    sed -Ez "s/(kind. Service.*name. application)/\1-${CI_ENVIRONMENT_NAME}/" -i route.yaml &&
 {%- endif %}
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: ${DOCKER_REGISTRY}/openshift/postgresql:9.6
+        image: docker-registry.default.svc:5000/openshift/postgresql:9.6
         imagePullPolicy: Always
         ports:
         - name: postgres

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "postgres"
+  name: postgres
 spec:
   replicas: 1
   revisionHistoryLimit: 2
-  serviceName: "postgres"
+  serviceName: postgres
   template:
     spec:
       containers:
@@ -17,7 +17,7 @@ spec:
           containerPort: 5432
         envFrom:
         - secretRef:
-            name: "postgres"
+            name: postgres
         livenessProbe:
           tcpSocket:
             port: postgres

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/service.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "postgres"
+  name: postgres
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
YAML! Watch the semicolons. Always.

Especially when your IDE does some apparently "weird" color coding. :roll_eyes: 

Also, the following objects are non-Kubernetes objects and hence not processed by `kustomize edit`, we need to add the environment suffix manually:

* Route
* Deployment 