### PR TITLE
Perform YAML linting in check stage

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -75,7 +75,5 @@ stages:
   - pushd deployment/application/base &&
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd
-  - kustomize build deployment/application/overlays/${CI_ENVIRONMENT_NAME} | kubeval --strict --ignore-missing-schemas
-  - kustomize build deployment/database/overlays/${CI_ENVIRONMENT_NAME} | kubeval --strict
   - kustomize build deployment/application/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -
   - kustomize build deployment/database/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -

--- a/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
@@ -3,3 +3,16 @@
   extends: .check
   script: tox -e {{ env }}
 {% endfor -%}
+
+{% if cookiecutter.container_platform != '(none)' %}
+kubernetes:
+  extends: .check
+  image: docker.io/appuio/oc:v3.11
+  script:
+  - kustomize build deployment/application/overlays/development | kubeval --strict --ignore-missing-schemas
+  - kustomize build deployment/application/overlays/integration | kubeval --strict --ignore-missing-schemas
+  - kustomize build deployment/application/overlays/production | kubeval --strict --ignore-missing-schemas
+  - kustomize build deployment/database/overlays/development | kubeval --strict
+  - kustomize build deployment/database/overlays/integration | kubeval --strict
+  - kustomize build deployment/database/overlays/production | kubeval --strict
+{% endif -%}


### PR DESCRIPTION
Moves the linting, which is currently performed right before the deployment, to the start of the pipeline, so that if the pipeline fails it fails early.

Unfortunately, this solution is more verbose. We need to check the YAML for all overlays (aka "target environments") otherwise a failing "production" configuration will not be discovered before a failing deployment.