### PR TITLE
Make sure deleting MRs doesn't fail when there are no MRs

### DIFF
--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -27,7 +27,8 @@ gitlab() {
 }
 
 log 1 'Delete existing merge requests'
-for IID in $(gitlab GET merge_requests?state=opened | sed -e 's/^.*"iid"://' -e 's/,".*$//'); do
+for IID in $(gitlab GET 'merge_requests?state=all&scope=all' \
+           | sed -e 's/^.*"iid"://' -e 's/,".*$//' -e '/^\[\]$/d'); do
     gitlab DELETE merge_requests/$IID
 done
 


### PR DESCRIPTION
As [discovered today](https://gitlab.com/painless-software/painless-continuous-delivery/-/jobs/402133961), deploying the field test (aka "demo") fails at trying to delete all open MRs. This happened because there we no MRs open anymore (they were closed manually).

Technically, the reason for the failure is that the response for the empty MR list is `[]` and the script interpreted this as an `IID`, a MR identifier.

In future we'll be deleting _all_ MRs by _any_ user (not just open MR by the requesting user).