### PR TITLE
Remove DOCKER_* variables from GitLab CI setup

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 
 variables:
-  DOCKER_DRIVER: overlay2
-  DOCKER_HOST: tcp://docker:2375
   DOCKER_REGISTRY: {{ cookiecutter.docker_registry }}
 {%- if cookiecutter.environment_strategy == 'shared' %}
   TARGET: {{ cookiecutter.project_slug }}


### PR DESCRIPTION
Removes two variables from the GitLab CI configuration, as suggested by @ccremer.