### PR TITLE
Enable GitLab pod logs

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -64,7 +64,11 @@ Initial Setup (APPUiO + GitLab)
 
    -  Operations > Kubernetes > "APPUiO" > Kubernetes cluster details > Service Token
 
-   (*Note:* Make sure "GitLab-managed cluster" is unchecked in the cluster details.)
+   and ensure the following values are set in the cluster details:
+
+   - RBAC-enabled cluster: *(checked)*
+   - GitLab-managed cluster: *(unchecked)*
+   - Project namespace: {% if cookiecutter.environment_strategy == 'shared' %}"{{ cookiecutter.project_slug }}"{% else %}*(empty)*{% endif %}
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
 
 #. Grant the service account permissions on the *development* and *integration*

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/development/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: development
+{%- endif %}
 commonLabels:
   environment: development
 {%- if cookiecutter.environment_strategy == 'shared' %}

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/integration/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: integration
+{%- endif %}
 commonLabels:
   environment: integration
 {%- if cookiecutter.environment_strategy == 'shared' %}

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/overlays/production/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: production
+{%- endif %}
 commonLabels:
   environment: production
 {%- if cookiecutter.environment_strategy == 'shared' %}


### PR DESCRIPTION
Via their Kubernetes integration GitLab provides [Pod Logs](https://docs.gitlab.com/ee/user/project/clusters/kubernetes_pod_logs.html), which would be a convenient way to [access logs of running pods](https://gitlab.com/appuio/example-django/-/logs) from the GitLab CI user interface. This is enabled by a simple set of annotations on pods, stateful sets and deployments according to the GitLab docs.

Related resources:
- [Kubernetes Pod Logs](https://docs.gitlab.com/ee/user/project/clusters/kubernetes_pod_logs.html)
- [Enabling Deploy Boards](https://docs.gitlab.com/ee/user/project/deploy_boards.html#enabling-deploy-boards)
- [Predefined environment variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
