### PR TITLE
Also expose database pod logs to GitLab

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/development/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: development
+{%- endif %}
 commonLabels:
   environment: development
 {%- if cookiecutter.environment_strategy == 'shared' %}

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/integration/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: integration
+{%- endif %}
 commonLabels:
   environment: integration
 {%- if cookiecutter.environment_strategy == 'shared' %}

--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/database/overlays/production/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+commonAnnotations:
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/env: production
+{%- endif %}
 commonLabels:
   environment: production
 {%- if cookiecutter.environment_strategy == 'shared' %}


### PR DESCRIPTION
Relates to #67, which exposed the application pod logs to GitLab.

The database pods have a separate Kustomize configuration, we need to do the same thing twice to have the same level of insight into all pods.