### PR TITLE
Upgrade Django and Django project dependencies

### DIFF
--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{111,21,22}
+envlist = django{111,22,30}
 skip_install = True
 skipsdist = True
 
@@ -8,8 +8,8 @@ recreate = True
 deps =
     autopep8
     django111: Django>=1.11,<2
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
     django-debug-toolbar
     django-environ
     flake8-django

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/base.in
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/base.in
@@ -1,4 +1,4 @@
-Django>=2.2,<3.0
+Django>=2.2.9,<3.0
 django-environ
 django-probes
 {% if cookiecutter.database == 'Postgres' -%}

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
@@ -6,21 +6,21 @@
 #
 django-environ==0.4.5
 django-probes==1.2.0
-django==2.2.4
-pytz==2019.2              # via django
+django==2.2.9
+pytz==2019.3              # via django
 sqlparse==0.3.0           # via django
 uwsgi==2.0.18
 {% if cookiecutter.database == 'Postgres' -%}
-psycopg2==2.8.3
+psycopg2==2.8.4
 {% elif cookiecutter.database == 'MySQL/MariaDB' -%}
 mysql-connector==2.2.9
 {% endif -%}
 {% if cookiecutter.monitoring == 'Datadog' -%}
 django-datadog==1.0.1
 {% elif cookiecutter.monitoring == 'NewRelic' -%}
-newrelic==4.20.0.120
+newrelic==5.4.1.134
 {% elif cookiecutter.monitoring == 'Sentry' -%}
-sentry-sdk==0.11.1
-certifi==2019.6.16        # via sentry-sdk
-urllib3==1.25.3           # via sentry-sdk
+sentry-sdk==0.14.0
+certifi==2019.11.28       # via sentry-sdk
+urllib3==1.25.7           # via sentry-sdk
 {% endif -%}


### PR DESCRIPTION
This change is meant to fix a vulnerability alert about the Django version hardcoded in the Django requirements file. We also upgrade all other dependencies for the Django project.