### PR TITLE
Mention tox in README, add descriptions to tox targets

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -29,7 +29,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 .. code-block:: bash
 
     # list all available test environments (= Tox targets)
-    tox -l
+    tox -lv
 
 .. code-block:: bash
 

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -25,6 +25,9 @@ If they fail the very first time simply restart the application.{% endif %}
 Open your web browser at http://localhost:8000 to see the application
 you're developing.  Log output will be displayed in the terminal, as usual.
 
+For running tests, linting, security checks, etc. see instructions in the
+`tests/ <tests/README.rst>`_ folder.
+
 {% if cookiecutter.container_platform == 'APPUiO' -%}
 Initial Setup (APPUiO + GitLab)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
@@ -1,18 +1,5 @@
-{% for env in cookiecutter.checks.split(",") %}
+{% for env in cookiecutter.checks.split(",") + ['kubernetes'] %}
 {{ env }}:
   extends: .check
   script: tox -e {{ env }}
 {% endfor -%}
-
-{% if cookiecutter.container_platform != '(none)' %}
-kubernetes:
-  extends: .check
-  image: docker.io/appuio/oc:v3.11
-  script:
-  - kustomize build deployment/application/overlays/development | kubeval --strict --ignore-missing-schemas
-  - kustomize build deployment/application/overlays/integration | kubeval --strict --ignore-missing-schemas
-  - kustomize build deployment/application/overlays/production | kubeval --strict --ignore-missing-schemas
-  - kustomize build deployment/database/overlays/development | kubeval --strict
-  - kustomize build deployment/database/overlays/integration | kubeval --strict
-  - kustomize build deployment/database/overlays/production | kubeval --strict
-{% endif -%}

--- a/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
@@ -29,7 +29,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 .. code-block:: bash
 
     # list all available test environments (= Tox targets)
-    tox -l
+    tox -lv
 
 .. code-block:: bash
 

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }}
+envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},requirements
 skipsdist = true
 
 [testenv]
+description = Unit tests
 deps =
     pytest
     -r {toxinidir}/requirements.txt
@@ -13,24 +14,29 @@ setenv =
 {%- endif %}
 
 [testenv:bandit]
+description = PyCQA security linter
 deps = bandit<1.6.0
 commands = bandit -r --ini tox.ini
 
 [testenv:flake8]
+description = Static code analysis and code style
 deps = flake8{% if cookiecutter.framework == 'Django' %}-django{% endif %}
 commands = flake8 {posargs}
 
 [testenv:pylint]
+description = Check for errors and code smells
 deps =
     pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
     -r {toxinidir}/requirements.txt
 commands = pylint --rcfile tox.ini {posargs:application}
 
 [testenv:safety]
+description = Check for vulnerable dependencies
 deps = safety
-commands = safety check -r requirements.txt
+commands = safety check --bare -r requirements.txt
 
 [testenv:behave]
+description = Acceptence tests (BDD)
 deps =
     behave{% if cookiecutter.framework == 'Django' %}-django{% endif %}
     -r {toxinidir}/requirements.txt
@@ -44,6 +50,7 @@ commands = behave {posargs}
 {%- endif %}
 
 [testenv:clean]
+description = Remove bytecode and other debris
 deps = pyclean
 whitelist_externals =
     rm
@@ -52,6 +59,7 @@ commands =
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
 
 [testenv:requirements]
+description = Update project dependencies
 deps = pip-tools
 commands = pip-compile --output-file=requirements/production.txt requirements/production.in --upgrade
 

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},requirements
+envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},kubernetes,requirements
 skipsdist = true
 
 [testenv]
@@ -62,6 +62,19 @@ commands =
 description = Update project dependencies
 deps = pip-tools
 commands = pip-compile --output-file=requirements/production.txt requirements/production.in --upgrade
+
+[testenv:kubernetes]
+description = Validate Kubernetes manifests
+deps = kustomize-wrapper
+commands =
+    kustomize lint --ignore-missing-schemas \
+        deployment/application/overlays/development \
+        deployment/application/overlays/integration \
+        deployment/application/overlays/production
+    kustomize lint \
+        deployment/database/overlays/development \
+        deployment/database/overlays/integration \
+        deployment/database/overlays/production
 
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests


### PR DESCRIPTION
* Adds information about development tooling (`tox`) to the project README
* Pimps up the `tox` targets a bit by adding explanatory descriptions
* Makes Kubernetes manifest validation available with `tox` (via [kustomize-wrapper](https://pypi.org/project/kustomize-wrapper/))
* Replaces the validation details in the pipeline configuration by a call to `tox`