### PR TITLE
Fix name clash of secret for application and route

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/base/route.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/python/deployment/application/base/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Route
 metadata:
-  name: application
+  name: application-route
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:


### PR DESCRIPTION
We discovered that under specific circumstances a secret is created that
contains data for the route, albeit the secret is named just like the
application secret.

Turns out that there is obviously a name clash between the secret the
ACME controller creates for the route (Let's Encrypt certificate) and
the secret we create for the application in the pipeline.