### PR TITLE
One more correction after field-testing

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/cronjob/jobs/backup/patch.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/cronjob/jobs/backup/patch.yaml
@@ -4,7 +4,7 @@
 - op: replace
   path: /spec/jobTemplate/spec/template/spec/containers/0/args
 {%- if cookiecutter.framework == 'Django' %}
-  value: ['python', 'manage.py', 'dumpdata', '-o', '/app/backups/db.json']
+  value: ['python manage.py dumpdata -o /app/backups/db.json ; cat /app/backups/db.json']
 {%- else %}
-  value: ['echo', 'hello world']
+  value: ['echo hello world']
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/cronjob/jobs/hello/patch.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/cronjob/jobs/hello/patch.yaml
@@ -3,4 +3,4 @@
   value: "*/5 * * * *"
 - op: replace
   path: /spec/jobTemplate/spec/template/spec/containers/0/args
-  value: ['echo', 'hello world']
+  value: ['echo hello world']


### PR DESCRIPTION
After field-testing the complex version, I found and corrected one more error:

Command arguments must be single strings, as those are arguments to the `bash` command.