### PR TITLE
Add documentation and cleanup for running the field test locally

### DIFF
--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -61,6 +61,8 @@ tox -e cookiecutter -- \
     push=force \
     --no-input
 
+cd /tmp/painless-generated-projects/example-django
+
 log 3 'Prepare feature branch'
 git checkout -b feature/welcome-page
 

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -8,12 +8,11 @@
 #
 # To run this field test locally:
 #  (1) Generate a Personal Access Token on GitLab 
-#      Top-right usesr menu > Settings > Access Tokens
+#      Top-right user menu > Settings > Access Tokens
 #  (2) export GITLAB_API_TOKEN=<your personal access token>
-#  (3) run ./tests/field/example-django.sh
-# The generated files are found in /tmp/painless-generated-project
+#  (3) run this script
+# The generated files are found in /tmp/painless-generated-projects
 # 
-
 set -e
 
 log() {
@@ -48,7 +47,6 @@ done
 
 log 2 'Create demo project from scratch and push it'
 tox -e cookiecutter -- \
-    -o /tmp/painless-generated-project \
     project_name="Example Django" \
     project_description="Hello world with Django" \
     vcs_platform=GitLab.com \
@@ -62,8 +60,6 @@ tox -e cookiecutter -- \
     license=GPL-3 \
     push=force \
     --no-input
-
-cd /tmp/painless-generated-project/example-django
 
 log 3 'Prepare feature branch'
 git checkout -b feature/welcome-page

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -6,6 +6,14 @@
 # The periodic regeneration is configured as a scheduled
 # pipeline in GitLab > CI/CD > Schedules.
 #
+# To run this field test locally:
+#  (1) Generate a Personal Access Token on GitLab 
+#      Top-right usesr menu > Settings > Access Tokens
+#  (2) export GITLAB_API_TOKEN=<your personal access token>
+#  (3) run ./tests/field/example-django.sh
+# The generated files are found in /tmp/painless-generated-project
+# 
+
 set -e
 
 log() {
@@ -40,6 +48,7 @@ done
 
 log 2 'Create demo project from scratch and push it'
 tox -e cookiecutter -- \
+    -o /tmp/painless-generated-project \
     project_name="Example Django" \
     project_description="Hello world with Django" \
     vcs_platform=GitLab.com \
@@ -54,7 +63,7 @@ tox -e cookiecutter -- \
     push=force \
     --no-input
 
-cd /tmp/example-django
+cd /tmp/painless-generated-project/example-django
 
 log 3 'Prepare feature branch'
 git checkout -b feature/welcome-page

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
     py3clean {toxinidir}
-    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-project
+    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-projects
 whitelist_externals =
     rm
 
@@ -49,7 +49,7 @@ commands = behave {posargs:--tags=-php}
 [testenv:cookiecutter]
 description = Isolated cookiecutter runner
 deps = cookiecutter
-changedir = /tmp
+changedir = /tmp/painless-generated-projects
 commands = cookiecutter {toxinidir} {posargs}
 passenv = *
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
     py3clean {toxinidir}
-    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
+    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-project
 whitelist_externals =
     rm
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,7 @@ commands = behave {posargs:--tags=-php}
 [testenv:cookiecutter]
 description = Isolated cookiecutter runner
 deps = cookiecutter
-changedir = /tmp/painless-generated-projects
-commands = cookiecutter {toxinidir} {posargs}
+commands = cookiecutter -o /tmp/painless-generated-projects {toxinidir} {posargs}
 passenv = *
 
 [bandit]


### PR DESCRIPTION
In order to simplify running the field test (deployment of the example project), this change adds a couple of beautifications:

- A comment in the top of the field test script explaining how to run it locally, and
- Moving the temporary output to a dedicated folder within the `/tmp` folder, allowing tox to cleanup the generated files between runs.