### PR TITLE
rename various postgres env vars for clarity

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -45,18 +45,20 @@ stages:
 .generate-secrets:
   variables:
     APPLICATION_NAME: application{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
-    DATABASE_NAME: postgres{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
+    POSTGRESQL_HOST: postgres{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
   before_script:
   - export DJANGO_SECRET_KEY=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c50)
   - export POSTGRESQL_PASSWORD=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
-  - export POSTGRESQL_USERNAME={{ cookiecutter.project_slug.replace('-', '_') }}
+  - export SANITIZED_NAME={{ cookiecutter.project_slug.replace('-', '_') }}
+  - export POSTGRESQL_USERNAME=${SANITIZED_NAME}
+  - export POSTGRESQL_DATABASE=${SANITIZED_NAME}
   - oc -n ${TARGET} get secret ${APPLICATION_NAME} ||
     oc -n ${TARGET} create secret generic ${APPLICATION_NAME}
-    --from-literal=DJANGO_DATABASE_URL=postgres://${POSTGRESQL_USERNAME}:${POSTGRESQL_PASSWORD}@${DATABASE_NAME}/{{ cookiecutter.project_slug.replace('-', '_') }}
+    --from-literal=DJANGO_DATABASE_URL=postgresql://${POSTGRESQL_USERNAME}:${POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}/${POSTGRESQL_DATABASE}
     --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
-  - oc -n ${TARGET} get secret ${DATABASE_NAME} ||
-    oc -n ${TARGET} create secret generic ${DATABASE_NAME}
-    --from-literal=POSTGRESQL_DATABASE={{ cookiecutter.project_slug.replace('-', '_') }}
+  - oc -n ${TARGET} get secret ${POSTGRESQL_HOST} ||
+    oc -n ${TARGET} create secret generic ${POSTGRESQL_HOST}
+    --from-literal=POSTGRESQL_DATABASE=${POSTGRESQL_DATABASE}
     --from-literal=POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}
     --from-literal=POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}
 


### PR DESCRIPTION
This clarifies the usage of the various variables in the secret generation.