### PR TITLE
update postgres image version

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/database/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/base/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: docker.io/bitnami/postgresql:9.6
+        image: docker.io/bitnami/postgresql:12
         imagePullPolicy: Always
         ports:
         - name: postgres

--- a/{{cookiecutter.project_slug}}/_/development/python/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/_/development/python/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
 {%- if cookiecutter.database == 'Postgres' %}
   database:
-    image: docker.io/bitnami/postgresql:9.6
+    image: docker.io/bitnami/postgresql:12
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
I tested this version on my example project, and it seems to work.  Note that the database files it creates are incompatible with the earlier version, so they should be deleted before redeploying (if using the same volume).