### PR TITLE
Make Shippable recognize Python 3.8

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-- 3.7
+- 3.8
 
 env:
   matrix:  # tox -l | xargs -I ARG echo '    - TOXENV=ARG'
@@ -19,7 +19,7 @@ env:
 
 matrix:
   allow_failures:
-  - env: TOXENV=bandit
+  - TOXENV=bandit
 
 build:
   ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-- 3.8
+- 3.7
 
 env:
   matrix:  # tox -l | xargs -I ARG echo '    - TOXENV=ARG'
@@ -13,7 +13,6 @@ env:
   - TOXENV=py35
   - TOXENV=py36
   - TOXENV=py37
-  - TOXENV=py38
   - TOXENV=pypy3
   - TOXENV=behave
 

--- a/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-- 3.8
+- 3.7
 
 env:
   matrix:  # tox -l | xargs -I ARG echo '    - TOXENV=ARG'

--- a/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/shippable.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-- 3.7
+- 3.8
 
 env:
   matrix:  # tox -l | xargs -I ARG echo '    - TOXENV=ARG'


### PR DESCRIPTION
Allow Bandit tests to fail