### PR TITLE
Allow to customize field test via CLI arguments

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -52,7 +52,7 @@
         "simple",
         "complex"
     ],
-    "checks": "bandit,flake8,pylint,safety",
+    "checks": "bandit,flake8,pylint,safety,kubernetes",
     "tests": "py37,behave",
     "monitoring": [
         "(none)",

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # NOTE: For the very first deployment please follow
 # the steps in the README for the target platform setup.
@@ -7,13 +7,10 @@
 # pipeline in GitLab > CI/CD > Schedules.
 #
 # To run this field test locally:
-#  (1) Generate a Personal Access Token on GitLab 
-#      Top-right user menu > Settings > Access Tokens
-#  (2) export GITLAB_API_TOKEN=<your personal access token>
-#  (3) run this script
-# The generated files are found in /tmp/painless-generated-projects
-# 
-set -e
+#  (1) Generate a Personal Access Token on GitLab. Top-right user menu > Settings > Access Tokens
+#  (2) `export GITLAB_API_TOKEN=<your personal access token>` in your terminal
+#  (3) Run this script. Additional parameters will be passed to cookiecutter (try `checks= tests=`).
+#  (4) Generated files are found in /tmp/painless-generated-projects
 
 log() {
     NOCOLOR='\033[0m'
@@ -59,6 +56,7 @@ tox -e cookiecutter -- \
     database=Postgres \
     license=GPL-3 \
     push=force \
+    ${*} \
     --no-input
 
 cd /tmp/painless-generated-projects/example-django

--- a/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/.gitlab-ci.yml
@@ -1,5 +1,5 @@
-{% for env in cookiecutter.checks.split(",") + ['kubernetes'] %}
+{% if cookiecutter.checks %}{% for env in cookiecutter.checks.split(",") | unique %}
 {{ env }}:
   extends: .check
   script: tox -e {{ env }}
-{% endfor -%}
+{% endfor %}{% endif -%}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.gitlab-ci.yml
@@ -1,5 +1,5 @@
-{% for env in cookiecutter.tests.split(",") %}
+{% if cookiecutter.tests %}{% for env in cookiecutter.tests.split(",") | unique %}
 {{ env }}:
   extends: .test
   script: tox -e {{ env }}
-{% endfor -%}
+{% endfor %}{% endif -%}


### PR DESCRIPTION
A simple change in the field test script allows us to, e.g., run a faster version of it (e.g. by not generating linting and tests in the CI setup).

There were some side-effects that I had to address in the template. That forced me to include the `kustomize` parameter value properly. :grimacing: :smile: 

Bottom line: Try running
```
./tests/field/example-django.sh checks= tests=
```
... and enjoy the speed! :racehorse: 