### PR TITLE
Use predefined variable for Git SHA on GitLab CI

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -76,7 +76,7 @@ stages:
   image: docker.io/appuio/oc:v3.11
   script:
   - echo "ENVIRONMENT=${CI_ENVIRONMENT_NAME}" >> deployment/application/base/application.env
-  - echo "REVISION=$(git rev-parse --short HEAD)" >> deployment/application/base/application.env
+  - echo "REVISION=${CI_COMMIT_SHORT_SHA}" >> deployment/application/base/application.env
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
            "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"


### PR DESCRIPTION
I recalled that GitLab already provides a [predefined variable](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) for the short commit hash. Interestingly, though, this is 8 characters long, not 7 as produced by `git` and used by GitHub and Bitbucket.

Still, it's probably advantageous to use the variable over the Git command, as the `git` binary may not be available in the container image in future (in fact, it is in the `appuio/co` image only because it is needed for the `cleanup` plugin, which is scheduled for removal once our reimplementation is in place).