### PR TITLE
Use Recreate strategy for deployments to Development

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -194,15 +194,19 @@ generated via:
     cookiecutter gh:painless-software/painless-continuous-delivery \
         project_name="{{ cookiecutter.project_name }}" \
         project_description="{{ cookiecutter.project_description }}" \
-        vcs_platform={{ cookiecutter.vcs_platform }} \
-        vcs_account={{ cookiecutter.vcs_account }} \
-        container_platform={{ cookiecutter.container_platform }} \
+        vcs_platform="{{ cookiecutter.vcs_platform }}" \
+        vcs_account="{{ cookiecutter.vcs_account }}" \
+        container_platform="{{ cookiecutter.container_platform }}" \
         container_platform_account="{{ cookiecutter.container_platform_account }}" \
-        environment_strategy={{ cookiecutter.environment_strategy }} \
-        cronjobs={{ cookiecutter.cronjobs }} \
-        framework={{ cookiecutter.framework }} \
-        database={{ cookiecutter.database }} \
-        license={{ cookiecutter.license }} \
+        environment_strategy="{{ cookiecutter.environment_strategy }}" \
+        docker_registry="{{ cookiecutter.docker_registry }}" \
+        framework="{{ cookiecutter.framework }}" \
+        database="{{ cookiecutter.database }}" \
+        cronjobs="{{ cookiecutter.cronjobs }}" \
+        checks="{{ cookiecutter.checks }}" \
+        tests="{{ cookiecutter.tests }}" \
+        monitoring="{{ cookiecutter.monitoring }}" \
+        license="{{ cookiecutter.license }}" \
         --no-input
 
 .. _Painless Continuous Delivery: https://github.com/painless-software/painless-continuous-delivery/

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/deployment.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: application
+spec:
+  strategy:
+    type: Recreate

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
@@ -1,22 +1,26 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -development
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-development
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:
-  environment: development
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-development
-nameSuffix: -development
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-development
 {%- endif %}
+  environment: development
 configMapGenerator:
 - name: application
   behavior: merge
   envs:
   - application.env
+resources:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
@@ -1,22 +1,24 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -integration
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-integration
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:
-  environment: integration
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-integration
-nameSuffix: -integration
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-integration
 {%- endif %}
+  environment: integration
 configMapGenerator:
 - name: application
   behavior: merge
   envs:
   - application.env
+resources:
+- ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
@@ -1,24 +1,26 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -production
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-production
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:
-  environment: production
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-production
-nameSuffix: -production
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-production
 {%- endif %}
+  environment: production
 configMapGenerator:
 - name: application
   behavior: merge
   envs:
   - application.env
+resources:
+- ../../base
 patchesStrategicMerge:
 - deployment.yaml

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
@@ -1,17 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -development
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-development
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:
-  environment: development
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-development
-nameSuffix: -development
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-development
 {%- endif %}
+  environment: development
+resources:
+- ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
@@ -1,17 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -integration
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-integration
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:
-  environment: integration
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-integration
-nameSuffix: -integration
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-integration
 {%- endif %}
+  environment: integration
+resources:
+- ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
@@ -1,17 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../../base
+{%- if cookiecutter.environment_strategy == 'shared' %}
+nameSuffix: -production
+{%- else %}
+namespace: {{ cookiecutter.project_slug }}-production
+{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:
-  environment: production
 {%- if cookiecutter.environment_strategy == 'shared' %}
   app: {{ cookiecutter.project_slug }}-production
-nameSuffix: -production
-{%- else %}
-namespace: {{ cookiecutter.project_slug }}-production
 {%- endif %}
+  environment: production
+resources:
+- ../../base


### PR DESCRIPTION
To save on resources, especially when deploying [Review Apps](https://docs.gitlab.com/ee/ci/review_apps/), we may want to use the `Recreate` [deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) in the "Development" environment, instead of Kubernetes' default `RollingUpdate` strategy.

Also, when we developers deploy an application under development (e.g. automatically from a PR or MR) we typically wouldn't care about a zero-downtime deployment. In fact, if something goes wrong with our current change we would simply try to fix the issue and have the pipeline redeploy the now-broken setup; and we would be disturbed to have to take care about taking down the struggling deployment (everbody loves "[CrashLoopBackOff](https://stackoverflow.com/questions/41604499/my-kubernetes-pods-keep-crashing-with-crashloopbackoff-but-i-cant-find-any-lo)", don't you?).

In the "Integration" environment we'll still have the `RollingUpdate` strategy by default, so we can see zero-downtime deployments in action and verify their functioning before releasing to "Production".

Hence, this change
* sets the deployment strategy to `Recreate` for the "Development" environment.

In addition, we
* reorder the elements in the involved YAML files more better readability (everybody wants "self-explanatory" code, don't you?),
* make sure the code sample in the README that shows how to recreate the project is complete.