### PR TITLE
Avoid creating ConfigMap objects with hash suffix

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+{%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.project_slug }}
+{%- endif %}
 commonLabels:
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   app: {{ cookiecutter.project_slug }}
@@ -9,15 +12,14 @@ configMapGenerator:
 - name: application
   envs:
   - application.env
-crds:
-- route-crd.yaml
-{%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.project_slug }}
-{%- endif %}
+generatorOptions:
+  disableNameSuffixHash: true
 {%- if cookiecutter.cronjobs == 'complex' %}
 bases:
 - cronjob
 {%- endif %}
+crds:
+- route-crd.yaml
 resources:
 {%- if cookiecutter.cronjobs == 'simple' %}
 - cronjob.yaml


### PR DESCRIPTION
We recently reached a quota limit with ConfigMap objects that filled up the namespace.
This should avoid the namespace to fill up in future.

I also reordered the YAML content a bit to more closely match the structure of the overlays. (Sorry about that!)

### Related documentation

* [Kustomize generatorOptions](https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#generatoroptions)