### PR TITLE
Clean up old ConfigMap objects to avoid quota exhaustion

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -81,9 +81,9 @@ stages:
   - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
            "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
 {%- endif %}
-  - for OBSOLETE in $(oc -n ${TARGET} get configmap --sort-by='.metadata.creationTimestamp' -o name
-      -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} | tail -n +5);
-      do oc -n ${TARGET} delete $OBSOLETE; done
+  - oc -n ${TARGET} get configmap -o name --sort-by='.metadata.creationTimestamp'
+       -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} |
+      tail -n +5 | xargs -r oc -n ${TARGET} delete
   - pushd deployment/application/base &&
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -72,7 +72,7 @@ stages:
   stage: deploy
   extends: .generate-secrets
   environment:
-    url: "${KUBE_URL}/console/project/{{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/overview"
+    url: "${KUBE_URL}/console/project/${CI_PROJECT_NAME}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/overview"
   image: docker.io/appuio/oc:v3.11
   script:
   - echo "ENVIRONMENT=${CI_ENVIRONMENT_NAME}" >> deployment/application/base/application.env
@@ -81,6 +81,9 @@ stages:
   - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
            "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
 {%- endif %}
+  - for OBSOLETE in $(oc -n ${TARGET} get configmap --sort-by='.metadata.creationTimestamp' -o name
+      -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} | tail -n +5);
+      do oc -n ${TARGET} delete $OBSOLETE; done
   - pushd deployment/application/base &&
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
     popd

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -21,9 +21,9 @@
         --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
         --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
     - &cleanup-configmaps
-      for OBSOLETE in $(oc get configmap --sort-by='.metadata.creationTimestamp' -o name
-        -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} | tail -n +5);
-        do oc delete $OBSOLETE; done
+      oc get configmap -o name --sort-by='.metadata.creationTimestamp'
+         -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} |
+        tail -n +5 | xargs -r oc delete
 
   - step: &deploy-review-app
       name: Deploy Review App

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -7,19 +7,23 @@
       DATABASE_NAME={{ cookiecutter.project_slug.replace('-', '_') }}
       DATABASE_USER={{ cookiecutter.project_slug.replace('-', '_') }}
     - &generate-secrets-app
-      oc -n ${TARGET} get secret ${APPLICATION} ||
-      oc -n ${TARGET} create secret generic ${APPLICATION}
+      oc get secret ${APPLICATION} ||
+      oc create secret generic ${APPLICATION}
         --from-literal=DJANGO_DATABASE_URL={{ cookiecutter.database|lower }}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}
         --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
   {%- if cookiecutter.monitoring == 'Sentry' %}
         --from-literal=SENTRY_DSN=${SENTRY_DSN}
   {%- endif %}
     - &generate-secrets-db
-      oc -n ${TARGET} get secret ${DATABASE_HOST} ||
-      oc -n ${TARGET} create secret generic ${DATABASE_HOST}
+      oc get secret ${DATABASE_HOST} ||
+      oc create secret generic ${DATABASE_HOST}
         --from-literal=POSTGRESQL_DATABASE=${DATABASE_NAME}
         --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
         --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
+    - &cleanup-configmaps
+      for OBSOLETE in $(oc get configmap --sort-by='.metadata.creationTimestamp' -o name
+        -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} | tail -n +5);
+        do oc delete $OBSOLETE; done
 
   - step: &deploy-review-app
       name: Deploy Review App
@@ -67,6 +71,7 @@
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
+      - *cleanup-configmaps
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db
@@ -92,6 +97,7 @@
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_TAG}"
+      - *cleanup-configmaps
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db


### PR DESCRIPTION
We recently reached a quota limit with ConfigMap objects that filled up the namespace.
This change cleans up the existing object, which should prevent quota exhaustion in future.

**Note:** This is an alternative solution to PR #100.