### PR TITLE
Bitbucket field test

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,22 +4,21 @@
 options:
     docker: true
 
+image: docker.io/painless/tox
+
 definitions:
   steps:
   - parallel: &checks
     - step:
         name: Flake8
-        image: docker.io/painless/tox
         script:
         - tox -e flake8
     - step:
         name: Pylint
-        image: docker.io/painless/tox
         script:
         - tox -e pylint
     - step:
         name: Bandit
-        image: docker.io/painless/tox
         script:
         - tox -e bandit || true
 
@@ -49,7 +48,7 @@ definitions:
         script:
         - tox -e behave
 
-  - steps: &field-test
+  - step: &field-test
       name: Deploy example-bitbucket
       deployment: Production
       script:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
         "GitHub.com"
     ],
     "vcs_account": "company-or-username",
+    "vcs_project": "{{ cookiecutter.project_slug }}",
     "ci_service": [
         ".gitlab-ci.yml",
         "bitbucket-pipelines.yml",
@@ -25,16 +26,17 @@
         "codeship-steps.yml",
         "shippable.yml"
     ],
-    "container_platform": [
+    "cloud_platform": [
         "(none)",
         "APPUiO"
     ],
-    "container_platform_account": "platform-username",
+    "cloud_account": "platform-username",
+    "cloud_project": "{{ cookiecutter.project_slug }}",
     "environment_strategy": [
         "shared",
         "dedicated"
     ],
-    "docker_registry": "{{ cookiecutter.container_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
+    "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
     "framework": [
         "(none)",
         "Django",

--- a/tests/field/example-bitbucket.sh
+++ b/tests/field/example-bitbucket.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+#
+# NOTE: For the very first deployment please follow
+# the steps in the README for the target platform setup.
+#
+# The periodic regeneration is configured as a scheduled
+# pipeline in GitLab > CI/CD > Schedules.
+#
+# To run this field test locally, see the instructions
+# in the CONTRIBUTING.rst document.
+
+BASEDIR=$(dirname $0)
+
+source ${BASEDIR}/include/logging.sh
+source ${BASEDIR}/include/api/bitbucket.sh

--- a/tests/field/example-bitbucket.sh
+++ b/tests/field/example-bitbucket.sh
@@ -13,3 +13,47 @@ BASEDIR=$(dirname $0)
 
 source ${BASEDIR}/include/logging.sh
 source ${BASEDIR}/include/api/bitbucket.sh
+
+log 1 'Delete existing merge requests, Git tags, etc.'
+# TODO: Bitbucket API operations
+
+log 2 'Create demo project from scratch and push it'
+tox -e cookiecutter -- \
+    project_name="Example Bitbucket" \
+    project_description="Hello world on Bitbucket" \
+    vcs_platform=Bitbucket.org \
+    vcs_account=appuio \
+    ci_service=bitbucket-pipelines.yml \
+    cloud_platform=APPUiO \
+    cloud_account="demo4501@appuio.ch" \
+    environment_strategy=dedicated \
+    cronjobs=complex \
+    framework=Django \
+    database=Postgres \
+    monitoring=Sentry \
+    license=GPL-3 \
+    push=force \
+    ${*} \
+    --no-input
+
+cd /tmp/painless-generated-projects/example-bitbucket
+
+log 3 'Prepare feature branch'
+# TODO: reuse existing code
+
+log 4 'Add an untested feature'
+# TODO: reuse existing code
+
+log 5 'Create merge request'
+# TODO: Bitbucket API operations
+
+log 6 'Allow pipeline to build and push an image'
+for minutes in $(seq 13 -1 1); do
+    echo "- Waiting... ($minutes' remaining)"
+    sleep 1m
+done
+
+log 7 'Trigger production release'
+git checkout master
+git tag 1.0.0
+git push --tags --force

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -9,23 +9,10 @@
 # To run this field test locally, see the instructions
 # in the CONTRIBUTING.rst document.
 
-log() {
-    NOCOLOR='\033[0m'
-    BLUE='\033[1;34m'
-    echo -e "$1) ${BLUE}${@:2}${NOCOLOR} ..."
-}
+BASEDIR=$(dirname $0)
 
-gitlab() {
-    COMMAND="$1"
-    RESOURCE="$2"
-    PROJECT_NAME="appuio%2Fexample-django"
-    PROJECT_URL="https://gitlab.com/api/v4/projects/${PROJECT_NAME}"
-    set -e
-    curl --silent \
-        --header "Authorization: Bearer $GITLAB_API_TOKEN" \
-        --request $COMMAND \
-        "${PROJECT_URL}/${RESOURCE}" "${@:3}"
-}
+source ${BASEDIR}/include/logging.sh
+source ${BASEDIR}/include/api/gitlab.sh
 
 log 1 'Delete existing merge requests, Git tags, etc.'
 for IID in $(gitlab GET 'merge_requests?state=all&scope=all' \

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -32,8 +32,9 @@ tox -e cookiecutter -- \
     project_description="Hello world with Django" \
     vcs_platform=GitLab.com \
     vcs_account=appuio \
-    container_platform=APPUiO \
-    container_platform_account="demo4501@appuio.ch" \
+    ci_service=.gitlab-ci.yml \
+    cloud_platform=APPUiO \
+    cloud_account="demo4501@appuio.ch" \
     environment_strategy=shared \
     cronjobs=simple \
     framework=Django \

--- a/tests/field/include/api/bitbucket.sh
+++ b/tests/field/include/api/bitbucket.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+#
+# Bitbucket API access helper functions.
+
+bitbucket() {
+    COMMAND="$1"
+    RESOURCE="$2"
+    PROJECT_NAME="appuio%2Fexample-django"
+    PROJECT_URL="https://gitlab.com/api/v4/projects/${PROJECT_NAME}"
+    set -e
+    curl --silent \
+        --header "Authorization: Bearer $GITLAB_API_TOKEN" \
+        --request $COMMAND \
+        "${PROJECT_URL}/${RESOURCE}" "${@:3}"
+}

--- a/tests/field/include/api/gitlab.sh
+++ b/tests/field/include/api/gitlab.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+#
+# GitLab API access helper functions.
+
+gitlab() {
+    COMMAND="$1"
+    RESOURCE="$2"
+    PROJECT_NAME="appuio%2Fexample-django"
+    PROJECT_URL="https://gitlab.com/api/v4/projects/${PROJECT_NAME}"
+    set -e
+    curl --silent \
+        --header "Authorization: Bearer $GITLAB_API_TOKEN" \
+        --request $COMMAND \
+        "${PROJECT_URL}/${RESOURCE}" "${@:3}"
+}

--- a/tests/field/include/logging.sh
+++ b/tests/field/include/logging.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+#
+# ANSI colored logging for the CI pipeline.
+
+log() {
+    NOCOLOR='\033[0m'
+    BLUE='\033[1;34m'
+    echo -e "$1) ${BLUE}${@:2}${NOCOLOR} ..."
+}

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -10,17 +10,31 @@ class TestCISetup:
     executed several times with different values (test scenarios).
     """
     scenarios = [
-        ('bitbucket', {
+        ('bitbucket-shared', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'bitbucket-pipelines.yml',
             'ci_testcommand': '        - tox -e py37',
-            'checks': 'flake8,pylint,bandit',
+            'checks': 'flake8,pylint,bandit,kubernetes',
             'tests': 'py35,py36,py37,pypy3,behave',
             'container_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target': '',
+            'expected_ci_target':
+                '        TARGET=${BITBUCKET_REPO_SLUG}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
+        }),
+        ('bitbucket-dedicated', {
+            'project_slug': 'myproject',
+            'vcs_account': 'painless-software',
+            'vcs_platform': 'Bitbucket.org',
+            'ci_service': 'bitbucket-pipelines.yml',
+            'ci_testcommand': '        - tox -e py37',
+            'checks': 'flake8,pylint,bandit,kubernetes',
+            'tests': 'py35,py36,py37,pypy3,behave',
+            'container_platform': 'APPUiO',
+            'environment_strategy': 'dedicated',
+            'expected_ci_target':
+                '        ${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
         }),
         ('codeship', {
             'project_slug': 'myproject',

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -18,10 +18,10 @@ class TestCISetup:
             'ci_testcommand': '        - tox -e py37',
             'checks': 'flake8,pylint,bandit,kubernetes',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target':
-                '        TARGET=${BITBUCKET_REPO_SLUG}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
+                '        TARGET=${BITBUCKET_REPO_SLUG}',
         }),
         ('bitbucket-dedicated', {
             'project_slug': 'myproject',
@@ -31,10 +31,10 @@ class TestCISetup:
             'ci_testcommand': '        - tox -e py37',
             'checks': 'flake8,pylint,bandit,kubernetes',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
             'expected_ci_target':
-                '        ${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
+                '        TARGET=${BITBUCKET_REPO_SLUG}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',  # noqa
         }),
         ('codeship', {
             'project_slug': 'myproject',
@@ -44,7 +44,7 @@ class TestCISetup:
             'ci_testcommand': '  service: app',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target': '',
         }),
@@ -56,7 +56,7 @@ class TestCISetup:
             'ci_testcommand': '  script: tox -e py37',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target':
                 '  TARGET: myproject',
@@ -69,7 +69,7 @@ class TestCISetup:
             'ci_testcommand': '  script: tox -e py37',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
             'expected_ci_target':
                 '    TARGET: myproject-production',
@@ -82,7 +82,7 @@ class TestCISetup:
             'ci_testcommand': '  - tox',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target': '',
         }),
@@ -94,7 +94,7 @@ class TestCISetup:
             'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
-            'container_platform': 'APPUiO',
+            'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target': '',
         }),
@@ -103,7 +103,7 @@ class TestCISetup:
     # pylint: disable=too-many-arguments,too-many-locals,no-self-use
     def test_ci_setup(self, cookies, project_slug, vcs_account, vcs_platform,
                       ci_service, ci_testcommand, checks, tests,
-                      container_platform, environment_strategy,
+                      cloud_platform, environment_strategy,
                       expected_ci_target):
         """
         Generate a CI setup with specific settings and verify it is complete.
@@ -115,7 +115,7 @@ class TestCISetup:
             'ci_service': ci_service,
             'checks': checks,
             'tests': tests,
-            'container_platform': container_platform,
+            'cloud_platform': cloud_platform,
             'environment_strategy': environment_strategy,
         })
 

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -28,7 +28,7 @@ you're developing.  Log output will be displayed in the terminal, as usual.
 For running tests, linting, security checks, etc. see instructions in the
 `tests/ <tests/README.rst>`_ folder.
 
-{% if cookiecutter.container_platform == 'APPUiO' -%}
+{% if cookiecutter.cloud_platform == 'APPUiO' -%}
 Initial Setup
 ^^^^^^^^^^^^^
 
@@ -223,8 +223,11 @@ generated via:
         project_description="{{ cookiecutter.project_description }}" \
         vcs_platform="{{ cookiecutter.vcs_platform }}" \
         vcs_account="{{ cookiecutter.vcs_account }}" \
-        container_platform="{{ cookiecutter.container_platform }}" \
-        container_platform_account="{{ cookiecutter.container_platform_account }}" \
+        vcs_project="{{ cookiecutter.vcs_project }}" \
+        ci_service="{{ cookiecutter.ci_service }}" \
+        cloud_platform="{{ cookiecutter.cloud_platform }}" \
+        cloud_account="{{ cookiecutter.cloud_account }}" \
+        cloud_project="{{ cookiecutter.cloud_project }}" \
         environment_strategy="{{ cookiecutter.environment_strategy }}" \
         docker_registry="{{ cookiecutter.docker_registry }}" \
         framework="{{ cookiecutter.framework }}" \

--- a/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
@@ -5,15 +5,23 @@
 pipelines:
   pull-requests:
     '**':
+    {%- if cookiecutter.checks %}
     - parallel: *checks
+    {%- endif %}
+    {%- if cookiecutter.tests %}
     - parallel: *tests
+    {%- endif %}
     - step: *build
     - step: *deploy-review-app
 
   branches:
     master:
+    {%- if cookiecutter.checks %}
     - parallel: *checks
+    {%- endif %}
+    {%- if cookiecutter.tests %}
     - parallel: *tests
+    {%- endif %}
     - step: *build
     - step: *deploy-integration
 

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
@@ -1,9 +1,13 @@
 options:
   docker: true
 
+image: docker.io/painless/tox
+
 definitions:
   steps:
-{% include '_/ci-services/lint-stage/%s' % cookiecutter.ci_service %}
-{% include '_/ci-services/test-stage/%s' % cookiecutter.ci_service %}
+{%- if cookiecutter.checks %}
+{% include '_/ci-services/lint-stage/%s' % cookiecutter.ci_service %}{% endif %}
+{%- if cookiecutter.tests %}
+{% include '_/ci-services/test-stage/%s' % cookiecutter.ci_service %}{% endif %}
 {% include '_/ci-services/build-stage/%s' % cookiecutter.ci_service %}
 {% include '_/ci-services/deploy-stage/%s' % cookiecutter.ci_service -%}

--- a/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/lint-stage/bitbucket-pipelines.yml
@@ -2,7 +2,6 @@
     {%- for env in cookiecutter.checks.split(",") %}
     - step:
         name: {{ env|capitalize }}
-        image: docker.io/painless/tox
         script:
         - tox -e {{ env }}
     {%- endfor %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
@@ -2,7 +2,6 @@
     {%- for env in cookiecutter.tests.split(",") %}
     - step:
         name: {{ env|replace('py35','Python 3.5')|replace('py36','Python 3.6')|replace('py37','Python 3.7')|replace('py38','Python 3.8')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
-        image: docker.io/painless/tox
         script:
         - tox -e {{ env }}
     {%- endfor %}

--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
@@ -19,4 +19,4 @@ roleRef:
   name: edit
 subjects:
 - kind: User
-  name: {{ cookiecutter.container_platform_account }}
+  name: {{ cookiecutter.cloud_account }}


### PR DESCRIPTION
* Adds a first draft of a field test for Bitbucket (no Bitbucket API calls, no cleanup of branches, etc.)
* Refactors the current field test setup to accommodate more (types of) field tests
* Renames cookiecutter properties `"container_*"` -> `"cloud_*"`
* Fixes this repository's Bitbucket Pipeline implementation
* Fixes glitches of generated Bitbucket Pipeline to allow reduced pipeline to run (e.g. field test via Tox)