### PR TITLE
Run seiso to clean up obsolete ImageStreamTags on OpenShift

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -80,6 +80,9 @@ stages:
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
            "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
+  - seiso images history "${TARGET}/${CI_PROJECT_NAME}" --force
+{%- else %}
+  - seiso images history "${TARGET}/${CI_PROJECT_NAME}-${CI_ENVIRONMENT_NAME}" --force
 {%- endif %}
   - oc -n ${TARGET} get configmap -o name --sort-by='.metadata.creationTimestamp'
        -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} |

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -20,7 +20,8 @@
         --from-literal=POSTGRESQL_DATABASE=${DATABASE_NAME}
         --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
         --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
-    - &cleanup-configmaps
+    - &cleanup-resources
+      seiso images history "${TARGET}/${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}" --force &&
       oc get configmap -o name --sort-by='.metadata.creationTimestamp'
          -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} |
         tail -n +5 | xargs -r oc delete
@@ -71,7 +72,7 @@
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
-      - *cleanup-configmaps
+      - *cleanup-resource
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db
@@ -97,7 +98,7 @@
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_TAG}"
-      - *cleanup-configmaps
+      - *cleanup-resources
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db


### PR DESCRIPTION
On APPUiO and other OpenShift clusters that enforce resource quotas we run out of image stream tags after a while unless we clean them up continuously.

These changes add VSHN's new [seiso](https://github.com/appuio/seiso#migrate-from-legacy-cleanup-plugin) tool, which is available from within the [appuio/oc](https://hub.docker.com/r/appuio/oc/) container image, to the CI/CD pipeline (GitLab CI and Bitbucket Pipelines, currently).

**Internal Reference:** VT-1354