### PR TITLE
Image streams are not named after any environment

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -80,10 +80,8 @@ stages:
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
            "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
-  - seiso images history "${TARGET}/${CI_PROJECT_NAME}" --force
-{%- else %}
-  - seiso images history "${TARGET}/${CI_PROJECT_NAME}-${CI_ENVIRONMENT_NAME}" --force
 {%- endif %}
+  - seiso images history "${TARGET}/${CI_PROJECT_NAME}" --force
   - oc -n ${TARGET} get configmap -o name --sort-by='.metadata.creationTimestamp'
        -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} |
       head -n -5 | xargs -r oc -n ${TARGET} delete

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -21,7 +21,7 @@
         --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
         --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
     - &cleanup-resources
-      seiso images history "${TARGET}/${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}" --force &&
+      seiso images history "${TARGET}/${BITBUCKET_REPO_SLUG}" --force &&
       oc get configmap -o name --sort-by='.metadata.creationTimestamp'
          -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} |
         tail -n +5 | xargs -r oc delete


### PR DESCRIPTION
The name of the image stream stays the same across all environments (aka namespaces), if any.

This change fixes an error introduced in #108.