### PR TITLE
Fix flake8-django namespace complaint

### DIFF
--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -44,7 +44,7 @@ commands =
     sed -i -E -z \
         -e 's/(from django.contrib import admin)/from django.conf import settings\n\1/' \
         -e 's/from django.urls import path/from django.urls import include, path/' \
-        -e "s|$|\nif settings.DEBUG:\n    import debug_toolbar  # pylint: disable=import-error\n\n    urlpatterns = [\n        path('__debug__/', include(debug_toolbar.urls)),\n    ] + urlpatterns\n|" \
+        -e "s|$|\nif settings.DEBUG:\n    import debug_toolbar  # pylint: disable=import-error\n\n    urlpatterns = [\n        path('__debug__/', include(debug_toolbar.urls, namespace='debug_toolbar')),\n    ] + urlpatterns\n|" \
         {toxworkdir}/{envname}/_/application/urls.py
     # TODO: Add LANGUAGES = [('en', _('English')),] next to LANGUAGE_CODE = 'en'
     # TODO: Add LocaleMiddleware (between SessionMiddleware and CommonMiddleware)

--- a/generators/tox.ini
+++ b/generators/tox.ini
@@ -19,3 +19,6 @@ commands = tox -c tox-typo3.ini
 [testenv:clean]
 commands = rm -rf {toxworkdir}
 whitelist_externals = rm
+
+[flake8]
+max-line-length = 88

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/urls.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/urls.py
@@ -25,5 +25,5 @@ if settings.DEBUG:
     import debug_toolbar  # pylint: disable=import-error
 
     urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
+        path('__debug__/', include(debug_toolbar.urls, namespace='debug_toolbar')),
     ] + urlpatterns

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements/production.txt
@@ -5,22 +5,22 @@
 #    pip-compile --output-file=requirements/production.txt requirements/production.in
 #
 {%- if cookiecutter.monitoring == 'Sentry' %}
-certifi==2019.11.28       # via sentry-sdk{% endif %}
+certifi==2020.4.5.1       # via sentry-sdk{% endif %}
 {%- if cookiecutter.monitoring == 'Datadog' %}
 django-datadog==1.0.1     # via -r requirements/base.in{% endif %}
 django-environ==0.4.5     # via -r requirements/base.in
-django-probes==1.2.0      # via -r requirements/base.in
-django==2.2.10            # via -r requirements/base.in
+django-probes==1.4.0      # via -r requirements/base.in
+django==2.2.12            # via -r requirements/base.in
 {%- if cookiecutter.database == 'MySQL' %}
 mysql-connector==2.2.9    # via -r requirements/base.in{% endif %}
 {%- if cookiecutter.monitoring == 'NewRelic' %}
-newrelic==5.8.0.136       # via -r requirements/base.in{% endif %}
+newrelic==5.12.0.140      # via -r requirements/base.in{% endif %}
 {%- if cookiecutter.database == 'Postgres' %}
-psycopg2==2.8.4           # via -r requirements/base.in{% endif %}
+psycopg2==2.8.5           # via -r requirements/base.in{% endif %}
 pytz==2019.3              # via django
 {%- if cookiecutter.monitoring == 'Sentry' %}
-sentry-sdk==0.14.2        # via -r requirements/base.in{% endif %}
+sentry-sdk==0.14.3        # via -r requirements/base.in{% endif %}
 sqlparse==0.3.1           # via django
 {%- if cookiecutter.monitoring == 'Sentry' %}
-urllib3==1.25.8           # via sentry-sdk{% endif %}
+urllib3==1.25.9           # via sentry-sdk{% endif %}
 uwsgi==2.0.18             # via -r requirements/production.in

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -91,6 +91,7 @@ summary = no
 
 [flake8]
 exclude = .cache,.git,.tox,build
+max-line-length = 88
 
 [pylint]
 [MASTER]


### PR DESCRIPTION
Demo [deployment on GitLab](https://gitlab.com/painless-software/painless-continuous-delivery/pipelines) was failing the last two days. This was due to [flake8-django](https://pypi.org/project/flake8-django/#history) now reporting additional warnings, which made the test suite of the generated demo project fail.

* Fixes the now newly reported warning in the Django code
* Extends the [maximum line length](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-line-length) accepted by `flake8` to `88` (the default used by [black](https://github.com/psf/black#line-length))
* Updates the Python/Django project dependencies