### PR TITLE
Set storage class for Postgres

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
@@ -9,6 +9,6 @@ commonLabels:
 namespace: {{ cookiecutter.project_slug }}
 {%- endif %}
 resources:
-- deployment.yaml
+- statefulset.yaml
 - secret.yaml
 - service.yaml

--- a/{{cookiecutter.project_slug}}/_/deployment/database/base/statefulset.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/base/statefulset.yaml
@@ -48,6 +48,9 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+{%- if cookiecutter.cloud_platform == 'APPUiO' %}
+        storageClassName: gluster-database
+{%- endif %}
         resources:
           requests:
             storage: 1Gi


### PR DESCRIPTION
If the cloud platform is APPUiO, use the `gluster-database` storage class for the
Postgres StatefulSet.

Relates to VT-1392

Signed-off-by: Simon Rüegg <simon@rueggs.ch>