### PR TITLE
Fix kubernetes manifest linting that fails

### DIFF
--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 metadata:
   name: admin
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: admin
 subjects:
@@ -15,6 +16,7 @@ kind: RoleBinding
 metadata:
   name: edit
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: edit
 subjects:

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -17,7 +17,7 @@ mysql-connector==2.2.9    # via -r requirements.in{% endif %}
 newrelic==5.12.0.140      # via -r requirements.in{% endif %}
 {%- if cookiecutter.database == 'Postgres' %}
 psycopg2==2.8.5           # via -r requirements.in{% endif %}
-pytz==2019.3              # via django
+pytz==2020.1              # via django
 {%- if cookiecutter.monitoring == 'Sentry' %}
 sentry-sdk==0.14.3        # via -r requirements.in{% endif %}
 sqlparse==0.3.1           # via django

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -19,28 +19,6 @@ description = PyCQA security linter
 deps = bandit<1.6.0
 commands = bandit -r --ini tox.ini
 
-[testenv:flake8]
-description = Static code analysis and code style
-deps = flake8{% if cookiecutter.framework == 'Django' %}-django{% endif %}
-commands = flake8 {posargs}
-
-[testenv:pylint]
-description = Check for errors and code smells
-deps =
-    pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
-    -r {toxinidir}/requirements.txt
-commands =
-    # generate directory list:
-    # $ ls */__init__.py | sed 's#/__init__.py# \\#g'
-    pylint --rcfile tox.ini {posargs: \
-        application \
-    }
-
-[testenv:safety]
-description = Check for vulnerable dependencies
-deps = safety
-commands = safety check --bare -r requirements.txt
-
 [testenv:behave]
 description = Acceptence tests (BDD)
 deps =
@@ -66,10 +44,10 @@ commands =
     py3clean -v {toxinidir}
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
 
-[testenv:requirements]
-description = Update project dependencies
-deps = pip-tools
-commands = pip-compile --output-file=requirements.txt requirements.in --upgrade
+[testenv:flake8]
+description = Static code analysis and code style
+deps = flake8{% if cookiecutter.framework == 'Django' %}-django{% endif %}
+commands = flake8 {posargs}
 
 [testenv:kubernetes]
 description = Validate Kubernetes manifests
@@ -85,6 +63,28 @@ commands =
         deployment/database/overlays/integration \
         deployment/database/overlays/production \
     }
+
+[testenv:pylint]
+description = Check for errors and code smells
+deps =
+    pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
+    -r {toxinidir}/requirements.txt
+commands =
+    # generate module list:
+    # $ ls */__init__.py | sed 's#/__init__.py# \\#g'
+    pylint --rcfile tox.ini {posargs: \
+        application \
+    }
+
+[testenv:requirements]
+description = Update project dependencies
+deps = pip-tools
+commands = pip-compile --output-file=requirements.txt requirements.in --upgrade
+
+[testenv:safety]
+description = Check for vulnerable dependencies
+deps = safety
+commands = safety check --bare -r requirements.txt
 
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},kubernetes,requirements
+envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},requirements
 skipsdist = true
 
 [testenv]
@@ -30,8 +30,11 @@ deps =
     pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
     -r {toxinidir}/requirements.txt
 commands =
+    # generate directory list:
+    # $ ls */__init__.py | sed 's#/__init__.py# \\#g'
     pylint --rcfile tox.ini {posargs: \
-        application}
+        application \
+    }
 
 [testenv:safety]
 description = Check for vulnerable dependencies
@@ -72,14 +75,16 @@ commands = pip-compile --output-file=requirements.txt requirements.in --upgrade
 description = Validate Kubernetes manifests
 deps = kustomize-wrapper
 commands =
-    kustomize lint --ignore-missing-schemas \
+    # generate directory list:
+    # $ ls -d1 deployment/*/overlays/* | sed 's/$/ \\/'
+    kustomize lint --ignore-missing-schemas {posargs: \
         deployment/application/overlays/development \
         deployment/application/overlays/integration \
-        deployment/application/overlays/production
-    kustomize lint \
+        deployment/application/overlays/production \
         deployment/database/overlays/development \
         deployment/database/overlays/integration \
-        deployment/database/overlays/production
+        deployment/database/overlays/production \
+    }
 
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests


### PR DESCRIPTION
Deployment of the Django example on GitLab.com currently fails. This is due to an update of the `kustomize-wrapper` Python package, which now correctly aborts on linting violations.

The changes fix the manifests `kubeval` complains about. It also updates the Tox configuration and a dependency version.