### PR TITLE
Use values of vcs_project and cloud_project consistently

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,11 +6,11 @@ image: painless/tox:multi
 .cookiecutter:
   stage: deploy
   before_script:
-  - git config --global user.name "Cookiecutter"
-  - git config --global user.email "cookiecutter@painless.software"
   - eval $(ssh-agent -s)
   - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
   - mkdir -p -m 700 ~/.ssh && echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+  - git config --global user.name "Cookiecutter"
+  - git config --global user.email "cookiecutter@painless.software"
   only:
   - master
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -143,7 +143,7 @@ def init_version_control():
         'platform_name': '{{ cookiecutter.vcs_platform }}',
         'platform': '{{ cookiecutter.vcs_platform.lower() }}',
         'account': '{{ cookiecutter.vcs_account }}',
-        'project': '{{ cookiecutter.project_slug }}',
+        'project': '{{ cookiecutter.vcs_project }}',
     }
     vcs_info['remote_uri'] = \
         'git@{platform}:{account}/{project}.git'.format(**vcs_info)

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -21,7 +21,7 @@ class TestCISetup:
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'expected_ci_target':
-                '        TARGET=${BITBUCKET_REPO_SLUG}',
+                '        TARGET=myproject',
         }),
         ('bitbucket-dedicated', {
             'project_slug': 'myproject',
@@ -34,7 +34,7 @@ class TestCISetup:
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
             'expected_ci_target':
-                '        TARGET=${BITBUCKET_REPO_SLUG}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',  # noqa
+                '        TARGET=myproject-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
         }),
         ('codeship', {
             'project_slug': 'myproject',

--- a/tests/unit/test_repos.py
+++ b/tests/unit/test_repos.py
@@ -10,7 +10,8 @@ class TestRepos:
     """
     scenarios = [
         ('Bitbucket/DockerHub', {
-            'project_slug': 'myproject',
+            'project_slug': 'custom-app',
+            'vcs_project': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'vcs_remote': 'git@bitbucket.org:painless-software/myproject.git',
@@ -18,7 +19,8 @@ class TestRepos:
             'docker_registry': 'hub.docker.com/painless-software',
         }),
         ('GitHub/Quay.io', {
-            'project_slug': 'myproject',
+            'project_slug': 'custom-app',
+            'vcs_project': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitHub.com',
             'vcs_remote': 'git@github.com:painless-software/myproject.git',
@@ -26,7 +28,8 @@ class TestRepos:
             'docker_registry': 'quay.io/painless-software',
         }),
         ('GitLab/Registry', {
-            'project_slug': 'myproject',
+            'project_slug': 'custom-app',
+            'vcs_project': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitLab.com',
             'vcs_remote': 'git@gitlab.com:painless-software/myproject.git',
@@ -36,8 +39,8 @@ class TestRepos:
     ]
 
     # pylint: disable=too-many-arguments,too-many-locals,no-self-use
-    def test_repos(self, cookies, project_slug, vcs_account, vcs_platform,
-                   vcs_remote, ci_service, docker_registry):
+    def test_repos(self, cookies, project_slug, vcs_project, vcs_account,
+                   vcs_platform, vcs_remote, ci_service, docker_registry):
         """
         Generate a Git repository ready to push, and a Docker setup
         referencing images on a Docker container registry service.
@@ -45,10 +48,11 @@ class TestRepos:
         result = cookies.bake(extra_context={
             'project_slug': project_slug,
             'vcs_platform': vcs_platform,
+            'vcs_project': vcs_project,
             'vcs_account': vcs_account,
             'ci_service': ci_service,
             'docker_registry': docker_registry,
-            'framework': 'Symfony',  # replace this once more are supported!!
+            'framework': 'Symfony',  # remove once docker-compose.final is gone
         })
 
         assert result.exit_code == 0

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -54,23 +54,23 @@ Initial Setup
    .. code-block:: console
 {% set service_account = cookiecutter.ci_service|replace('.yml', '')|replace('.', '')|replace('-steps', '')|replace('travis', 'travis-ci') %}
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
-        oc -n {{ cookiecutter.project_slug }}-production create sa {{ service_account }}
-        oc -n {{ cookiecutter.project_slug }}-production policy add-role-to-user admin -z {{ service_account }}
-        oc -n {{ cookiecutter.project_slug }}-production sa get-token {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }}-production create sa {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }}-production policy add-role-to-user admin -z {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }}-production sa get-token {{ service_account }}
 {%- else %}
-        oc -n {{ cookiecutter.project_slug }} create sa {{ service_account }}
-        oc -n {{ cookiecutter.project_slug }} policy add-role-to-user admin -z {{ service_account }}
-        oc -n {{ cookiecutter.project_slug }} sa get-token {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }} create sa {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }} policy add-role-to-user admin -z {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }} sa get-token {{ service_account }}
 {%- endif %}
 {%- if service_account == 'bitbucket-pipelines' %}
 
 #. Note down service account token and your cluster's URL, and
 
    - at `Settings > Pipelines > Settings
-     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/admin/addon/admin/pipelines/settings>`_,
+     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/admin/addon/admin/pipelines/settings>`_,
      check "Enable Pipelines",
    - at `Settings > Pipelines > Repository variables
-     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/admin/addon/admin/pipelines/repository-variables>`_
+     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/admin/addon/admin/pipelines/repository-variables>`_
      configure the following environment variables, which allow the pipeline
      to integrate with your container platform:
 
@@ -80,7 +80,7 @@ Initial Setup
 #. Rename the default deployment environments at
 
    - `Settings > Deployments
-     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/admin/addon/admin/pipelines/deployment-settings>`_
+     <https://bitbucket.org/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/admin/addon/admin/pipelines/deployment-settings>`_
 
    as follows:
 
@@ -89,7 +89,7 @@ Initial Setup
 {%- elif service_account == 'gitlab-ci' %}
 
 #. Use the service account token to configure the
-   `Kubernetes integration <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/-/clusters>`_
+   `Kubernetes integration <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/clusters>`_
    of your GitLab project: (`GitLab docs <https://docs.gitlab.com/ee/user/project/clusters/>`_)
 
    - Operations > Kubernetes > "APPUiO" > Kubernetes cluster details > Service Token
@@ -98,7 +98,7 @@ Initial Setup
 
    - RBAC-enabled cluster: *(checked)*
    - GitLab-managed cluster: *(unchecked)*
-   - Project namespace: {% if cookiecutter.environment_strategy == 'shared' %}"{{ cookiecutter.project_slug }}"{% else %}*(empty)*{% endif %}
+   - Project namespace: {% if cookiecutter.environment_strategy == 'shared' %}"{{ cookiecutter.cloud_project }}"{% else %}*(empty)*{% endif %}
 {%- endif %}
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
 
@@ -107,10 +107,10 @@ Initial Setup
 
    .. code-block:: console
 
-        oc -n {{ cookiecutter.project_slug }}-integration policy add-role-to-user \
-          admin system:serviceaccount:{{ cookiecutter.project_slug }}-production:{{ service_account }}
-        oc -n {{ cookiecutter.project_slug }}-development policy add-role-to-user \
-          admin system:serviceaccount:{{ cookiecutter.project_slug }}-production:{{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }}-integration policy add-role-to-user \
+          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }}-development policy add-role-to-user \
+          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ service_account }}
 {%- endif %}
 {%- endif %}
 {%- if cookiecutter.monitoring == 'Sentry' %}
@@ -120,10 +120,10 @@ Integrate External Tools
 
 :Sentry:
   - Add environment variable ``SENTRY_DSN`` in
-    `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/-/settings/ci_cd>`_
+    `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`_
   - Delete secrets in your namespace and run a deployment (to recreate them)
-  - Configure `Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/-/error_tracking>`_
-    in `Settings > Operations > Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.project_slug }}/-/settings/operations>`_
+  - Configure `Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/error_tracking>`_
+    in `Settings > Operations > Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/operations>`_
 {%- endif %}
 
 Working with Docker

--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/.gitlab-ci.yml
@@ -5,7 +5,7 @@ application:
     name: development
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   variables:
-    TARGET: {{ cookiecutter.project_slug }}-development
+    TARGET: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
   only:
   - merge_requests

--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
@@ -5,7 +5,7 @@
       - docker
       script:
       - REGISTRY={{ cookiecutter.docker_registry }}
-        TARGET=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
+        TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
         IMAGE="${REGISTRY}/${TARGET}/${BITBUCKET_REPO_SLUG}"
       - docker login -u bitbucket-pipelines -p ${KUBE_TOKEN} ${REGISTRY}
       - docker pull "${IMAGE}:latest" || true

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 variables:
   DOCKER_REGISTRY: {{ cookiecutter.docker_registry }}
 {%- if cookiecutter.environment_strategy == 'shared' %}
-  TARGET: {{ cookiecutter.project_slug }}
+  TARGET: {{ cookiecutter.cloud_project }}
 {%- endif %}
 
 services:
@@ -72,7 +72,7 @@ stages:
   stage: deploy
   extends: .generate-secrets
   environment:
-    url: "${KUBE_URL}/console/project/${CI_PROJECT_NAME}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/overview"
+    url: "${KUBE_URL}/console/project/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/overview"
   image: docker.io/appuio/oc:v3.11
   script:
   - echo "ENVIRONMENT=${CI_ENVIRONMENT_NAME}" >> deployment/application/base/application.env

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -5,8 +5,8 @@ development:
     name: development
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   variables:
-    SOURCE: {{ cookiecutter.project_slug }}-development
-    TARGET: {{ cookiecutter.project_slug }}-development
+    SOURCE: {{ cookiecutter.cloud_project }}-development
+    TARGET: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
   only:
   - merge_requests
@@ -17,8 +17,8 @@ integration:
     name: integration
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   variables:
-    SOURCE: {{ cookiecutter.project_slug }}-development
-    TARGET: {{ cookiecutter.project_slug }}-integration
+    SOURCE: {{ cookiecutter.cloud_project }}-development
+    TARGET: {{ cookiecutter.cloud_project }}-integration
 {%- endif %}
   only:
   - master
@@ -29,8 +29,8 @@ production:
     name: production
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   variables:
-    SOURCE: {{ cookiecutter.project_slug }}-integration
-    TARGET: {{ cookiecutter.project_slug }}-production
+    SOURCE: {{ cookiecutter.cloud_project }}-integration
+    TARGET: {{ cookiecutter.cloud_project }}-production
 {%- endif %}
   only:
   - tags

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -31,7 +31,7 @@
       deployment: development
       image: docker.io/appuio/oc:v3.11
       script:
-      - TARGET=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
+      - TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
         REVIEW_APP=review-pr${BITBUCKET_PR_ID}
         APPLICATION=${REVIEW_APP}-application
         DATABASE_HOST=${REVIEW_APP}-{{ cookiecutter.database|lower }}
@@ -67,8 +67,8 @@
       deployment: integration
       image: docker.io/appuio/oc:v3.11
       script:
-      - SOURCE=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
-        TARGET=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
+      - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
+        TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
@@ -93,8 +93,8 @@
       deployment: production
       image: docker.io/appuio/oc:v3.11
       script:
-      - SOURCE=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-integration{% endif %}
-        TARGET=${BITBUCKET_REPO_SLUG}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
+      - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-integration{% endif %}
+        TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
       - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
                "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_TAG}"

--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.project_slug }}
+namespace: {{ cookiecutter.cloud_project }}
 {%- endif %}
 commonLabels:
 {%- if cookiecutter.environment_strategy == 'dedicated' %}

--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/rolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: gitlab-ci
-  namespace: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'dedicated' %}-production{% endif %}
+  namespace: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-production{% endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -development
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-development
+namespace: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -integration
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-integration
+namespace: {{ cookiecutter.cloud_project }}-integration
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -production
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-production
+namespace: {{ cookiecutter.cloud_project }}-production
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:

--- a/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
 {%- endif %}
   component: database
 {%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.project_slug }}
+namespace: {{ cookiecutter.cloud_project }}
 {%- endif %}
 resources:
 - statefulset.yaml

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -development
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-development
+namespace: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -integration
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-integration
+namespace: {{ cookiecutter.cloud_project }}-integration
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
 nameSuffix: -production
 {%- else %}
-namespace: {{ cookiecutter.project_slug }}-production
+namespace: {{ cookiecutter.cloud_project }}-production
 {%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
-  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.project_slug }}
+  app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:


### PR DESCRIPTION
This removes the hard assumption that everyone would want to align:

- application name,
- repository project name, and
- cloud project name

... allowing to override the aligned values (which remains the default behavior).

Technically, this means:

- The (main) application remains the slug of the project name (e.g. "Example Django" ➜ "example-django")
- Source code repository projects now refer to "VCS project" (<s>`project_slug`</s> ➜ `vcs_project`)
- Kubernetes namespaces now refer to "cloud project" (<s>`project_slug`</s> ➜ `cloud_project`)

Note that the new [cookiecutter variables](https://github.com/painless-software/painless-continuous-delivery/blob/master/cookiecutter.json#L20-L34) were already introduced earlier.