### PR TITLE
Integrate more Seiso commands

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
@@ -6,7 +6,7 @@
       script:
       - REGISTRY={{ cookiecutter.docker_registry }}
         TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
-        IMAGE="${REGISTRY}/${TARGET}/${BITBUCKET_REPO_SLUG}"
+        IMAGE="${REGISTRY}/${TARGET}/{{ cookiecutter.project_slug }}"
       - docker login -u bitbucket-pipelines -p ${KUBE_TOKEN} ${REGISTRY}
       - docker pull "${IMAGE}:latest" || true
       - docker build -t "${IMAGE}:${BITBUCKET_COMMIT}"

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -36,7 +36,7 @@ stages:
   stage: build
   image: docker.io/library/docker
   variables:
-    IMAGE: ${DOCKER_REGISTRY}/${TARGET}/${CI_PROJECT_NAME}
+    IMAGE: ${DOCKER_REGISTRY}/${TARGET}/{{ cookiecutter.project_slug }}
   before_script:
   - docker login -u gitlab-ci -p ${KUBE_TOKEN} ${DOCKER_REGISTRY}
   - docker pull "${IMAGE}:latest" || true
@@ -55,15 +55,16 @@ stages:
   before_script:
   - export DJANGO_SECRET_KEY=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c50)
   - export DATABASE_PASSWORD=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
-  - oc -n ${TARGET} get secret ${APPLICATION_NAME} ||
-    oc -n ${TARGET} create secret generic ${APPLICATION_NAME}
+  - oc project ${TARGET}
+  - oc get secret ${APPLICATION_NAME} ||
+    oc create secret generic ${APPLICATION_NAME}
       --from-literal=DJANGO_DATABASE_URL={{ cookiecutter.database|lower }}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}
       --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
 {%- if cookiecutter.monitoring == 'Sentry' %}
       --from-literal=SENTRY_DSN=${SENTRY_DSN}
 {%- endif %}
-  - oc -n ${TARGET} get secret ${DATABASE_HOST} ||
-    oc -n ${TARGET} create secret generic ${DATABASE_HOST}
+  - oc get secret ${DATABASE_HOST} ||
+    oc create secret generic ${DATABASE_HOST}
       --from-literal=POSTGRESQL_DATABASE=${DATABASE_NAME}
       --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
       --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
@@ -78,15 +79,15 @@ stages:
   - echo "ENVIRONMENT=${CI_ENVIRONMENT_NAME}" >> deployment/application/base/application.env
   - echo "REVISION=${CI_COMMIT_SHORT_SHA}" >> deployment/application/base/application.env
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
-  - oc tag "${SOURCE}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
-           "${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}"
+  - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}"
+           "${TARGET}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}"
 {%- endif %}
-  - seiso images history "${TARGET}/${CI_PROJECT_NAME}" --force
-  - oc -n ${TARGET} get configmap -o name --sort-by='.metadata.creationTimestamp'
-       -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} |
-      head -n -5 | xargs -r oc -n ${TARGET} delete
+  - seiso configmaps -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} --delete
+  - seiso secrets -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} --delete
+  - seiso image history {{ cookiecutter.project_slug }} --delete
+  - seiso image orphans {{ cookiecutter.project_slug }} --delete
   - pushd deployment/application/base &&
-    kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${CI_PROJECT_NAME}:${CI_COMMIT_SHA}" &&
+    kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}" &&
     popd
   - kustomize build deployment/application/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -
   - kustomize build deployment/database/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -21,10 +21,10 @@
         --from-literal=POSTGRESQL_USERNAME=${DATABASE_USER}
         --from-literal=POSTGRESQL_PASSWORD=${DATABASE_PASSWORD}
     - &cleanup-resources
-      seiso images history "${TARGET}/${BITBUCKET_REPO_SLUG}" --force &&
-      oc get configmap -o name --sort-by='.metadata.creationTimestamp'
-         -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} |
-        tail -n +5 | xargs -r oc delete
+      seiso configmaps -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} --delete &&
+      seiso secrets -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %} --delete &&
+      seiso image history {{ cookiecutter.project_slug }} --delete &&
+      seiso image orphans {{ cookiecutter.project_slug }} --delete
 
   - step: &deploy-review-app
       name: Deploy Review App
@@ -35,12 +35,12 @@
         REVIEW_APP=review-pr${BITBUCKET_PR_ID}
         APPLICATION=${REVIEW_APP}-application
         DATABASE_HOST=${REVIEW_APP}-{{ cookiecutter.database|lower }}
-      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
+      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n ${TARGET}
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db
       - pushd deployment/application/base &&
-        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}" &&
+        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}" &&
         popd
       - pushd deployment/application/overlays/${BITBUCKET_DEPLOYMENT_ENVIRONMENT} &&
         kustomize edit add label app:${REVIEW_APP} -f &&
@@ -70,14 +70,14 @@
       - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
         TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
-      - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
-               "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
+      - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
+               "${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
       - *cleanup-resource
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db
       - pushd deployment/application/base &&
-        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}" &&
+        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}" &&
         popd
       - kustomize build deployment/application/overlays/${BITBUCKET_DEPLOYMENT_ENVIRONMENT} | oc apply -f -
       - kustomize build deployment/database/overlays/${BITBUCKET_DEPLOYMENT_ENVIRONMENT} | oc apply -f -
@@ -96,14 +96,14 @@
       - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-integration{% endif %}
         TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
       - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
-      - oc tag "${SOURCE}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_COMMIT}"
-               "${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_TAG}"
+      - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
+               "${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_TAG}"
       - *cleanup-resources
       - *generate-secrets-vars
       - *generate-secrets-app
       - *generate-secrets-db
       - pushd deployment/application/base &&
-        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/${BITBUCKET_REPO_SLUG}:${BITBUCKET_TAG}" &&
+        kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_TAG}" &&
         popd
       - kustomize build deployment/application/overlays/${BITBUCKET_DEPLOYMENT_ENVIRONMENT} | oc apply -f -
       - kustomize build deployment/database/overlays/${BITBUCKET_DEPLOYMENT_ENVIRONMENT} | oc apply -f -

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -55,7 +55,7 @@ deps = kustomize-wrapper
 commands =
     # generate directory list:
     # $ ls -d1 deployment/*/overlays/* | sed 's/$/ \\/'
-    kustomize lint --ignore-missing-schemas {posargs: \
+    kustomize lint {posargs:--ignore-missing-schemas --fail-fast \
         deployment/application/overlays/development \
         deployment/application/overlays/integration \
         deployment/application/overlays/production \


### PR DESCRIPTION
For the cleanup of cloud resources (obsolete ConfigMap and Secret objects, obsolete images and image tags) [Seiso](https://github.com/appuio/seiso) can now do all of them. Using just the `seiso` command can help in getting the related pipeline sections more easily readable.

This change set also covers some additional correction of the references / naming of the built container images, which can now remain to be the project slug even when the repository project is named differently (relates to issue #126).