### PR TITLE
Deploy review apps with GitLab CI

### DIFF
--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -15,96 +15,146 @@ class TestCISetup:
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'bitbucket-pipelines.yml',
-            'ci_testcommand': '        - tox -e py37',
             'checks': 'flake8,pylint,bandit,kubernetes',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target':
+            'required_lines': [
                 '        TARGET=myproject',
+                '        - tox -e py37',
+            ],
         }),
         ('bitbucket-dedicated', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'bitbucket-pipelines.yml',
-            'ci_testcommand': '        - tox -e py37',
             'checks': 'flake8,pylint,bandit,kubernetes',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
-            'expected_ci_target':
+            'required_lines': [
                 '        TARGET=myproject-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}',
+                '        - tox -e py37',
+            ],
         }),
         ('codeship', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitHub.com',
             'ci_service': 'codeship-steps.yml',
-            'ci_testcommand': '  service: app',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target': '',
+            'required_lines': [
+                '  service: app',
+            ],
         }),
         ('gitlab-shared', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitLab.com',
             'ci_service': '.gitlab-ci.yml',
-            'ci_testcommand': '  script: tox -e py37',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target':
+            'required_lines': [
                 '  TARGET: myproject',
+                '  script: tox -e py37',
+                '.deploy-vars:',
+                '.generate-secrets:',
+                '.deploy:',
+                '  extends: .deploy-vars',
+                '  extends: .generate-secrets',
+                '  - seiso configmaps -l app=${LABEL} --delete',
+                '  - seiso secrets -l app=${LABEL} --delete',
+                '  - seiso image history myproject --delete',
+                '  - seiso image orphans myproject --delete',
+                '  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/application/'
+                'overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml',
+                '  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/database/'
+                'overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml',
+                '    LABEL: review-mr${CI_MERGE_REQUEST_IID}',
+                '    APPLICATION: application-'
+                'review-mr${CI_MERGE_REQUEST_IID}',
+                '    DATABASE_HOST: postgres-'
+                'review-mr${CI_MERGE_REQUEST_IID}',
+                'stop_review:',
+                '  - oc delete all,configmap,pvc,secret -n ${TARGET}'
+                ' -l app=${LABEL}',
+            ],
         }),
         ('gitlab-dedicated', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitLab.com',
             'ci_service': '.gitlab-ci.yml',
-            'ci_testcommand': '  script: tox -e py37',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
-            'expected_ci_target':
+            'required_lines': [
                 '    TARGET: myproject-production',
+                '  script: tox -e py37',
+                '.deploy-vars:',
+                '.generate-secrets:',
+                '.deploy:',
+                '  extends: .deploy-vars',
+                '  extends: .generate-secrets',
+                '  - oc tag "${SOURCE}/myproject:${CI_COMMIT_SHA}"',
+                '           "${TARGET}/myproject:${CI_COMMIT_SHA}"',
+                '  - seiso configmaps -l app=${LABEL} --delete',
+                '  - seiso secrets -l app=${LABEL} --delete',
+                '  - seiso image history myproject --delete',
+                '  - seiso image orphans myproject --delete',
+                '  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/application/'
+                'overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml',
+                '  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/database/'
+                'overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml',
+                '    LABEL: review-mr${CI_MERGE_REQUEST_IID}',
+                '    APPLICATION: application-'
+                'review-mr${CI_MERGE_REQUEST_IID}',
+                '    DATABASE_HOST: postgres-'
+                'review-mr${CI_MERGE_REQUEST_IID}',
+                'stop_review:',
+                '  - oc delete all,configmap,pvc,secret -n ${TARGET}'
+                ' -l app=${LABEL}',
+            ],
         }),
         ('shippable', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'Bitbucket.org',
             'ci_service': 'shippable.yml',
-            'ci_testcommand': '  - tox',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target': '',
+            'required_lines': [
+                '  - tox',
+            ],
         }),
         ('travis', {
             'project_slug': 'myproject',
             'vcs_account': 'painless-software',
             'vcs_platform': 'GitHub.com',
             'ci_service': '.travis.yml',
-            'ci_testcommand': 'script: tox',
             'checks': 'flake8,pylint,bandit',
             'tests': 'py35,py36,py37,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
-            'expected_ci_target': '',
+            'required_lines': [
+                'script: tox',
+            ],
         }),
     ]
 
     # pylint: disable=too-many-arguments,too-many-locals,no-self-use
     def test_ci_setup(self, cookies, project_slug, vcs_account, vcs_platform,
-                      ci_service, ci_testcommand, checks, tests,
-                      cloud_platform, environment_strategy,
-                      expected_ci_target):
+                      ci_service, checks, tests, cloud_platform,
+                      environment_strategy, required_lines):
         """
         Generate a CI setup with specific settings and verify it is complete.
         """
@@ -115,6 +165,7 @@ class TestCISetup:
             'ci_service': ci_service,
             'checks': checks,
             'tests': tests,
+            'database': 'Postgres',
             'cloud_platform': cloud_platform,
             'environment_strategy': environment_strategy,
         })
@@ -127,11 +178,9 @@ class TestCISetup:
         assert result.project.join('README.rst').isfile()
 
         ci_service_conf = result.project.join(ci_service).readlines(cr=False)
-        assert ci_testcommand in ci_service_conf, \
-            "Test command not found in CI config: '%s'" % ci_testcommand
-        assert expected_ci_target in ci_service_conf, \
-            "Deployment target not found in CI config: '%s'\n%s" \
-            % (expected_ci_target, '\n'.join(ci_service_conf))
+        for line in required_lines:
+            assert line in ci_service_conf, "Not found in CI config: " \
+                "'%s'\n%s" % (line, '\n'.join(ci_service_conf))
 
         codeship_services = result.project.join('codeship-services.yml')
         assert (ci_service == 'codeship-steps.yml' and

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -20,7 +20,7 @@ class TestDatabase:
                 'DATABASES': {
                     'default': env_db(
                         "'DJANGO_DATABASE_URL',",
-                        "default='sqlite://%s' % join(BASE_DIR, 'db.sqlite3')"
+                        "default='sqlite://%s' % join(BASE_DIR, 'db.sqlite3')",
                     ),
                 },
             },
@@ -36,7 +36,8 @@ class TestDatabase:
                 'DATABASES': {
                     'default': env_db(
                         "'DJANGO_DATABASE_URL',",
-                        "default='postgres://postgres:postgres@database/postgres'"  # noqa
+                        "default='postgres://"
+                        "postgres:postgres@database/postgres'",
                     ),
                 },
             },
@@ -53,7 +54,7 @@ class TestDatabase:
                 'DATABASES': {
                     'default': env_db(
                         "'DJANGO_DATABASE_URL',",
-                        "default='mysql://mysql:mysql@database/mysql'"
+                        "default='mysql://mysql:mysql@database/mysql'",
                     ),
                 },
             },

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -41,7 +41,8 @@ class TestFramework:
                 ('docker-compose.yml', [
                     '    environment:',
                     '      - DJANGO_DEBUG=True',
-                    '    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]',  # noqa
+                    '    command: '
+                    '["python", "manage.py", "runserver", "0.0.0.0:8000"]',
                     '    ports:',
                     '      - "8000:8000"',
                 ]),

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ summary = no
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
+max-line-length = 82
 
 [pylint]
 [MASTER]

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ summary = no
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
-max-line-length = 82
 
 [pylint]
 [MASTER]

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -49,7 +49,7 @@ Initial Setup
 #. With the commands below, create a service account from your terminal
    (logging in to your cluster first), grant permissions to push images
    and apply configurations, and get the service account's token value:
-   (`APPUiO docs <https://appuio-community-documentation.readthedocs.io/en/latest/services/webserver/50_pushing_to_appuio.html>`_)
+   (`APPUiO docs <https://docs.appuio.ch/en/latest/services/webserver/50_pushing_to_appuio.html>`_)
 
    .. code-block:: console
 {% set service_account = cookiecutter.ci_service|replace('.yml', '')|replace('.', '')|replace('-steps', '')|replace('travis', 'travis-ci') %}
@@ -198,8 +198,9 @@ We have 3 environments corresponding to 3 deployments in a single namespace
 on our container platform: *development*, *integration*, *production*
 {%- endif %}
 
-- Any merge request triggers a deployment (of the feature branch) on
-  *development*.
+- Any merge request triggers a deployment of a review app on *development*.
+  When a merge request is merged or closed the review app will automatically
+  be removed.
 - Any change on the main branch, e.g. when a merge request is merged into
   ``master``, triggers a deployment on *integration*.
 - To trigger a deployment on *production* push a Git tag, e.g.

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -46,18 +46,22 @@ stages:
                  -f "deployment/application/Dockerfile" .
   - docker push "${IMAGE}"
 
-.generate-secrets:
+.deploy-vars:
   variables:
-    APPLICATION_NAME: application{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
+    LABEL: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
+    APPLICATION: application{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
     DATABASE_HOST: {{ cookiecutter.database|lower }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %}
     DATABASE_NAME: {{ cookiecutter.project_slug.replace('-', '_') }}
     DATABASE_USER: {{ cookiecutter.project_slug.replace('-', '_') }}
+
+.generate-secrets:
+  extends: .deploy-vars
   before_script:
   - export DJANGO_SECRET_KEY=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c50)
   - export DATABASE_PASSWORD=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
   - oc project ${TARGET}
-  - oc get secret ${APPLICATION_NAME} ||
-    oc create secret generic ${APPLICATION_NAME}
+  - oc get secret ${APPLICATION} ||
+    oc create secret generic ${APPLICATION}
       --from-literal=DJANGO_DATABASE_URL={{ cookiecutter.database|lower }}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}
       --from-literal=DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
 {%- if cookiecutter.monitoring == 'Sentry' %}
@@ -82,12 +86,14 @@ stages:
   - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}"
            "${TARGET}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}"
 {%- endif %}
-  - seiso configmaps -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} --delete
-  - seiso secrets -l app={{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-${CI_ENVIRONMENT_NAME}{% endif %} --delete
+  - seiso configmaps -l app=${LABEL} --delete
+  - seiso secrets -l app=${LABEL} --delete
   - seiso image history {{ cookiecutter.project_slug }} --delete
   - seiso image orphans {{ cookiecutter.project_slug }} --delete
   - pushd deployment/application/base &&
     kustomize edit set image IMAGE="docker-registry.default.svc:5000/${TARGET}/{{ cookiecutter.project_slug }}:${CI_COMMIT_SHA}" &&
     popd
+  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/application/overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml
+  - sed "s|REVIEW-ID|${LABEL}|" -i deployment/database/overlays/${CI_ENVIRONMENT_NAME}/kustomization.yaml
   - kustomize build deployment/application/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -
   - kustomize build deployment/database/overlays/${CI_ENVIRONMENT_NAME} | oc apply -f -

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -1,15 +1,30 @@
 
-development:
+review:
   extends: .deploy
   environment:
     name: development
-{%- if cookiecutter.environment_strategy == 'dedicated' %}
+    on_stop: stop_review
   variables:
+    LABEL: review-mr${CI_MERGE_REQUEST_IID}
+    APPLICATION: application-review-mr${CI_MERGE_REQUEST_IID}
+    DATABASE_HOST: {{ cookiecutter.database|lower }}-review-mr${CI_MERGE_REQUEST_IID}
+{%- if cookiecutter.environment_strategy == 'dedicated' %}
     SOURCE: {{ cookiecutter.cloud_project }}-development
     TARGET: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
   only:
   - merge_requests
+
+stop_review:
+  extends: review
+  environment:
+    action: stop
+  variables:
+    GIT_STRATEGY: none
+  when: manual
+  before_script:
+  script:
+  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}
 
 integration:
   extends: .deploy

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -69,7 +69,7 @@
       script:
       - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
         TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
-      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
+      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n ${TARGET}
       - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
                "${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
       - *cleanup-resource
@@ -95,7 +95,7 @@
       script:
       - SOURCE={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-integration{% endif %}
         TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${BITBUCKET_DEPLOYMENT_ENVIRONMENT}{% endif %}
-      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n "${TARGET}"
+      - oc login ${KUBE_URL} --token="${KUBE_TOKEN}" -n ${TARGET}
       - oc tag "${SOURCE}/{{ cookiecutter.project_slug }}:${BITBUCKET_COMMIT}"
                "${TARGET}/{{ cookiecutter.project_slug }}:${BITBUCKET_TAG}"
       - *cleanup-resources

--- a/{{cookiecutter.project_slug}}/_/deployment/application/base/route.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/base/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Route
 metadata:
-  name: application-route
+  name: {{ cookiecutter.project_slug }}
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
@@ -1,11 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-{%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.cloud_project }}
+namespace: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
 nameSuffix: -REVIEW-ID
-{%- else %}
-namespace: {{ cookiecutter.cloud_project }}-development
-{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
-nameSuffix: -development
+namespace: {{ cookiecutter.cloud_project }}
+nameSuffix: -REVIEW-ID
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-development
-{%- endif %}
+  app: REVIEW-ID
   environment: development
 configMapGenerator:
 - name: application

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/development/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
 nameSuffix: -REVIEW-ID
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: development

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.cloud_project }}
 nameSuffix: -integration
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-integration
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-integration
-{%- endif %}
+  app: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-integration{% endif %}
   environment: integration
 configMapGenerator:
 - name: application

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/integration/kustomization.yaml
@@ -6,7 +6,7 @@ nameSuffix: -integration
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-integration
 {%- endif %}
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: integration

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.cloud_project }}
 nameSuffix: -production
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-production
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-production
-{%- endif %}
+  app: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-production{% endif %}
   environment: production
 configMapGenerator:
 - name: application

--- a/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/application/overlays/production/kustomization.yaml
@@ -6,7 +6,7 @@ nameSuffix: -production
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-production
 {%- endif %}
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: production

--- a/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/base/kustomization.yaml
@@ -1,12 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+{%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.cloud_project }}
+{%- endif %}
 commonLabels:
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
   app: {{ cookiecutter.project_slug }}
 {%- endif %}
   component: database
 {%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.cloud_project }}
 {%- endif %}
 resources:
 - statefulset.yaml

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
@@ -1,11 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-{%- if cookiecutter.environment_strategy == 'shared' %}
-namespace: {{ cookiecutter.cloud_project }}
+namespace: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
 nameSuffix: -REVIEW-ID
-{%- else %}
-namespace: {{ cookiecutter.cloud_project }}-development
-{%- endif %}
 {%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
-nameSuffix: -development
+namespace: {{ cookiecutter.cloud_project }}
+nameSuffix: -REVIEW-ID
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-development
 {%- endif %}
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: development
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-development
-{%- endif %}
+  app: REVIEW-ID
   environment: development
 resources:
 - ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/development/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
 nameSuffix: -REVIEW-ID
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: development

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.cloud_project }}
 nameSuffix: -integration
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-integration
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: integration
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-integration
-{%- endif %}
+  app: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-integration{% endif %}
   environment: integration
 resources:
 - ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/integration/kustomization.yaml
@@ -6,7 +6,7 @@ nameSuffix: -integration
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-integration
 {%- endif %}
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: integration

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 {%- if cookiecutter.environment_strategy == 'shared' %}
+namespace: {{ cookiecutter.cloud_project }}
 nameSuffix: -production
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-production
@@ -11,9 +12,7 @@ commonAnnotations:
   app.gitlab.com/env: production
 {%- endif %}
 commonLabels:
-{%- if cookiecutter.environment_strategy == 'shared' %}
-  app: {{ cookiecutter.project_slug }}-production
-{%- endif %}
+  app: {{ cookiecutter.project_slug }}{% if cookiecutter.environment_strategy == 'shared' %}-production{% endif %}
   environment: production
 resources:
 - ../../base

--- a/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/_/deployment/database/overlays/production/kustomization.yaml
@@ -6,7 +6,7 @@ nameSuffix: -production
 {%- else %}
 namespace: {{ cookiecutter.cloud_project }}-production
 {%- endif %}
-{%- if cookiecutter.vcs_platform == 'GitLab.com' and cookiecutter.environment_strategy == 'shared' %}
+{%- if cookiecutter.vcs_platform == 'GitLab.com' %}
 commonAnnotations:
   app.gitlab.com/app: {{ cookiecutter.vcs_account|lower }}-{{ cookiecutter.vcs_project|lower }}
   app.gitlab.com/env: production


### PR DESCRIPTION
Instead of a single "development" instance per "development" environment, we want to deploy a [review app](https://docs.gitlab.com/ee/ci/review_apps/) instance per each and every merge request to the "development" environment. That instance is automatically cleaned up once the merge request is merged or closed.

### Hints for reviewer

Deployed project with "dedicated" environment strategy:
- GitLab: [appuio/demo-development](https://gitlab.com/appuio/demo-development)
- APPUiO: [example-bitbucket-*](https://console.appuio.ch/console/project/example-bitbucket-development/overview) :roll_eyes: 

Deployed project with "shared" environment strategy:
- GitLab: [appuio/example-django](https://gitlab.com/appuio/example-django)
- APPUiO: [example-django](https://console.appuio.ch/console/project/example-django/overview) :smile: 