### PR TITLE
Move instructions on testing to tests/README

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,47 +12,10 @@ fix bugs or typos your help is greatly appreciated!
   enforced by `flake8`_ and `Pylint`_ (PEP8 et al.).
 - Please add tests and make sure the builds all pass (run ``tox`` locally).
 
-Testing
--------
-
-We use `tox`_ to run tests against all target environments.  You may want to
-use `pyenv`_ to test against all Python version locally.  Alternatively, you
-can test only against the versions you already have installed on your machine
-as follows, wait for the build servers to cover the missing pieces and fix
-identified issues with additional commits:
-
-.. code-block:: console
-
-    tox -e flake8,pylint,py36,py37
-
-We have field tests to generate and deploy an example project from your
-local working version.  In order to run the deployment, you need to have
-access to the GitLab repository of your target generated project (such as
-`example django`_), and you need to generate a Personal Access Token on 
-GitLab. (Top-right user menu > Settings > Access Tokens)
-
-.. code-block:: console
-
-    export GITLAB_API_TOKEN=<your personal access token>
-    tox -e clean,fieldtest -- django
-
-Generated files are found in `/tmp/painless-generated-projects`
-
-Tests that require Docker must be run locally on your developer machine,
-because not all CI servers allow running Docker (inside Docker) on their
-infrastructure.  In `behave`_ tests the related scenarios are tagged with
-``@docker``.  Run them with:
-
-.. code-block:: console
-
-    tox -e behave -- --tags=docker
+Please see the `tests/README <tests/README.rst>`__ for details on testing.
 
 
 .. _pull request: https://github.com/painless-software/painless-continuous-delivery/pulls
 .. _bug tracker: https://github.com/painless-software/painless-continuous-delivery/issues
 .. _flake8: http://flake8.readthedocs.io/en/latest/
 .. _Pylint: https://pylint.org/
-.. _tox: http://tox.readthedocs.io/en/latest/
-.. _pyenv: https://github.com/yyuu/pyenv#basic-github-checkout
-.. _behave: https://behave.readthedocs.io/en/latest/
-.. _example django: https://gitlab.com/appuio/example-django

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -9,53 +9,105 @@ Philosophy
 ----------
 
 No need to install additional packages for running tests
-    All dependencies for running your tests are specified in ``tox.ini``.
-    (Tox_ will create virtual environments and install those packages
-    automagically when running your tests.)
+    All dependencies for running your tests are specified in ``tox.ini``
 
-.. _Tox: https://tox.readthedocs.io/en/latest/
+    `Tox`_ will create virtual environments and install those packages
+    automagically when running your tests.
 
-Running Your Tests Locally
---------------------------
+Linting and Unit Tests
+----------------------
+
+We use `Tox`_ to run our entire tests suite, including all supported Python
+versions.  You may want to use `pyenv`_ to install all Python versions locally.
+Alternatively, you can test only against the versions you already have
+installed on your machine as follows, wait for the build servers to cover the
+missing ones, and fix identified issues (if any) with additional commits:
+
+.. code-block:: console
+
+    tox -e flake8,pylint,py36,py37
+
+Field Tests
+-----------
+
+We have field tests to generate and deploy an example project from your
+local working version.  In order to run the deployment, you need to have
+access to the GitLab repository of your target generated project (such as
+`example django`_), and you need to generate a Personal Access Token on
+GitLab. (Top-right user menu > Settings > Access Tokens)
+
+.. code-block:: console
+
+    export GITLAB_API_TOKEN=<your personal access token>
+    tox -e clean,fieldtest django
+
+Generated files are found in ``/tmp/painless-generated-projects``
+
+Running Docker in Tests
+------------------------
+
+Tests that require Docker must be run locally on your developer machine,
+because not all CI servers allow running Docker (inside Docker) on their
+infrastructure.  In `behave`_ tests the related scenarios are tagged with
+``@docker``.  Run them with:
+
+.. code-block:: console
+
+    tox -e behave -- --tags=docker
+
+Working with Tox
+----------------
 
 Install Tox on your local machine:
 
-.. code-block:: bash
+.. code-block:: console
 
     pip install tox
 
 Use the ``tox`` command in the terminal to run your tests locally:
 
-.. code-block:: bash
+.. code-block:: console
 
     # list all available test environments (= Tox targets)
     tox -lv
 
-.. code-block:: bash
+.. code-block:: console
 
     # run all tests against all environments
     tox
 
-.. code-block:: bash
+.. code-block:: console
 
     # run a specific set of tests (one or several)
-    tox -e py35
-    tox -e flake8,py35
+    tox -e py37
+    tox -e flake8,py37
 
-.. code-block:: bash
+.. code-block:: console
 
     # remove all environments, build files and folders
     tox -e clean
 
-If you need to use command line arguments for a command separate them with a
-double-dash, like so::
+If you need to use command line options for a command separate them with a
+double-dash, like so:
+
+.. code-block:: console
 
      tox <tox args> -- <command args>
 
 Examples:
 
-.. code-block:: bash
+.. code-block:: console
 
     tox -e behave -- --format=pretty
     tox -e behave -- --tags=-docker
     tox -e flake8 -- --help
+
+
+.. _Tox: https://tox.readthedocs.io/en/latest/
+.. _pull request: https://github.com/painless-software/painless-continuous-delivery/pulls
+.. _bug tracker: https://github.com/painless-software/painless-continuous-delivery/issues
+.. _flake8: http://flake8.readthedocs.io/en/latest/
+.. _Pylint: https://pylint.org/
+.. _pyenv: https://github.com/yyuu/pyenv#basic-github-checkout
+.. _behave: https://behave.readthedocs.io/en/latest/
+.. _example django: https://gitlab.com/appuio/example-django

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -135,4 +135,5 @@ class TestTestingSetup:
 
         # ensure this project itself stays up-to-date with the template
         for filename in match_project_root:
-            verify_file_matches_repo_root(result, filename)
+            verify_file_matches_repo_root(result, filename,
+                                          max_compare_bytes=375)

--- a/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
@@ -9,9 +9,10 @@ Philosophy
 ----------
 
 No need to install additional packages for running tests
-    All dependencies for running your tests are specified in ``tox.ini``.
-    (Tox_ will create virtual environments and install those packages
-    automagically when running your tests.)
+    All dependencies for running your tests are specified in ``tox.ini``
+
+    `Tox`_ will create virtual environments and install those packages
+    automagically when running your tests.
 
 .. _Tox: https://tox.readthedocs.io/en/latest/
 


### PR DESCRIPTION
Some instructions on running tests, specifically the ones on field tests, were included in the CONTRIBUTING document, which is not a bad place to include it, per se. However, other instructions on runnings the test suite are included in tests/README, which makes related information harder to find.

It likely makes sense to move all related information into a single place and point to there from all other places.