### PR TITLE
Make review apps die automatically after a day

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -4,6 +4,7 @@ review:
   environment:
     name: development
     on_stop: stop_review
+    auto_stop_in: 1 day
   variables:
     LABEL: review-mr${CI_MERGE_REQUEST_IID}
     APPLICATION: application-review-mr${CI_MERGE_REQUEST_IID}


### PR DESCRIPTION
We build our demos on a daily basis. Hence, at least one new MR will be opened each day, which corresponds to another review app being deployed. The old one would *not* disappear automatically.

We could add "deleting of all review apps" to the field test script, but the `auto-stop` GitLab feature seems just good enough, so that we can spare the effort.

### Related reading

- [GitLab docs](https://docs.gitlab.com/ee/ci/environments/index.html#environments-auto-stop)