### PR TITLE
Exclude database in manifest linting and init-container

### DIFF
--- a/tests/acceptance/features/php.feature
+++ b/tests/acceptance/features/php.feature
@@ -5,14 +5,14 @@ Feature: Painless Continuous Delivery project setup powered by Cookiecutter
 
   @php
   Scenario Outline: Default tests pass after project generation
-    Given I have just created a <framework> project checking <checks> and testing <tests>
+    Given I have just created a <framework> <database> project checking <checks> and testing <tests>
     And system libraries have been installed for developing with PHP
     When I run the test suite with <testcommands>
     Then all tests pass successfully
 
     Examples: PHP frameworks
-      | framework | checks            | tests          | testcommands                    |
-      | Symfony   | phpcs,twig,jshint | phpunit,jsunit | composer check && composer test |
+      | framework | database | checks            | tests          | testcommands                    |
+      | Symfony   | MySQL    | phpcs,twig,jshint | phpunit,jsunit | composer check && composer test |
 
   @php @docker
   Scenario Outline: Starting to develop is simple and quick

--- a/tests/acceptance/features/python.feature
+++ b/tests/acceptance/features/python.feature
@@ -4,11 +4,11 @@ Feature: Painless Continuous Delivery project setup powered by Cookiecutter
   So that I get a working best-practice setup for software development
 
   Scenario Outline: Default tests pass after project generation
-    Given I have just created a <framework> project checking <checks> and testing <tests>
+    Given I have just created a <framework> <database> project checking <checks> and testing <tests>
     When I run the test suite with <commands>
     Then all tests pass successfully
 
     Examples: Python frameworks
-      | framework | checks        | tests       | commands |
-      | Django    | flake8,pylint | py37,behave | tox      |
-      | Flask     | flake8,pylint | py37,behave | tox      |
+      | framework | database | checks                   | tests       | commands |
+      | Django    | Postgres | flake8,pylint,kubernetes | py37,behave | tox      |
+      | Flask     | (none)   | flake8,pylint,kubernetes | py37,behave | tox      |

--- a/tests/acceptance/steps/given.py
+++ b/tests/acceptance/steps/given.py
@@ -5,8 +5,8 @@ from os import system
 from cookiecutter.main import cookiecutter
 
 
-@given('I have just created a {framework} project checking {checks} and testing {tests}')  # noqa
-def step_impl(context, framework, checks, tests):
+@given('I have just created a {framework} {database} project checking {checks} and testing {tests}')  # noqa
+def step_impl(context, framework, database, checks, tests):
 
     project_slug = 'painless-%s-project' % framework.lower()
     context.set_logfilename(project_slug)
@@ -18,9 +18,9 @@ def step_impl(context, framework, checks, tests):
         extra_context={
             'project_slug': project_slug,
             'framework': framework,
+            'database': database,
             'checks': checks,
             'tests': tests,
-            'database': 'MySQL',
             'vcs_platform': 'GitLab.com',
             'ci_service': '.gitlab-ci.yml',
         })

--- a/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.txt
@@ -9,5 +9,5 @@ flask==1.1.2              # via -r requirements.in
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 markupsafe==1.1.1         # via jinja2
-uwsgi==2.0.19.1             # via -r requirements.in
+uwsgi==2.0.19.1           # via -r requirements.in
 werkzeug==1.0.1           # via flask

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -59,9 +59,11 @@ commands =
         deployment/application/overlays/development \
         deployment/application/overlays/integration \
         deployment/application/overlays/production \
+        {%- if cookiecutter.database != '(none)' %}
         deployment/database/overlays/development \
         deployment/database/overlays/integration \
         deployment/database/overlays/production \
+        {%- endif %}
     }
 
 [testenv:pylint]

--- a/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
@@ -10,6 +10,7 @@ spec:
       labels:
         name: application
     spec:
+      {%- if cookiecutter.database != '(none)' %}
       initContainers:
       - name: wait-for-database
         image: IMAGE
@@ -23,6 +24,7 @@ spec:
             name: application
         - secretRef:
             name: application
+      {%- endif %}
       containers:
       - name: {{ cookiecutter.framework|lower }}
         image: IMAGE


### PR DESCRIPTION
Dealing with database artifacts also needs to be excluded in manifest linting and the init-container of the deployment when a database is not specified.

We also extend the acceptance tests, covering database setup creation and manifest linting, to let related issues slip through less easily.

This is a follow-up on #171.