### PR TITLE
Allow deployment steps to access KUBE_* values (GitLab CI)

### DIFF
--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -216,6 +216,8 @@ class TestGitops:
                     dedent("""
                     review:
                       extends: .tag-image
+                      environment:
+                        name: development
                       variables:
                         IMAGE_TAG: review-mr${CI_MERGE_REQUEST_IID}
                       only:
@@ -224,6 +226,8 @@ class TestGitops:
                     dedent("""
                     integration:
                       extends: .tag-image
+                      environment:
+                        name: integration
                       variables:
                         IMAGE_TAG: latest
                       only:
@@ -232,6 +236,8 @@ class TestGitops:
                     dedent("""
                     production:
                       extends: .tag-image
+                      environment:
+                        name: production
                       variables:
                         IMAGE_TAG: "${CI_COMMIT_TAG}"
                       only:

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 {%- if cookiecutter.deployment_strategy == 'gitops' %}
 review:
   extends: .tag-image
+  environment:
+    name: development
   variables:
     IMAGE_TAG: review-mr${CI_MERGE_REQUEST_IID}
   only:
@@ -8,6 +10,8 @@ review:
 
 integration:
   extends: .tag-image
+  environment:
+    name: integration
   variables:
     IMAGE_TAG: latest
   only:
@@ -15,6 +19,8 @@ integration:
 
 production:
   extends: .tag-image
+  environment:
+    name: production
   variables:
     IMAGE_TAG: "${CI_COMMIT_TAG}"
   only:


### PR DESCRIPTION
As we know from our pipeline implementation experience, GitLab CI only injects the `KUBE_*` variables [when we specify an `environment`](https://docs.gitlab.com/ee/user/project/clusters/index.html#deployment-variables). This is the fix for the recent GitOps implementation.