### PR TITLE
Use vanilla Kubernetes manifests for Rancher (replacing Route et al.)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Supported Technologies and Services
 ..                   GitLab CI  - |gitlab-ci|
 ..                   Shippable  - |shippable|
 ..                   Travis CI  - |travis-ci|
-**App Platforms**    APPUiO (OpenShift, Kubernetes)
+**App Platforms**    APPUiO (OpenShift)
+                     Rancher (Kubernetes)
 ==================== =========================================================
 
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -47,7 +47,6 @@
     "docker_image": "{{ cookiecutter.project_slug }}",
     "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
-    "flux_ssh_known_hosts": "",
     "framework": [
         "(none)",
         "Django",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,7 +29,8 @@
     ],
     "cloud_platform": [
         "(none)",
-        "APPUiO"
+        "APPUiO",
+        "Rancher"
     ],
     "cloud_account": "platform-username",
     "cloud_project": "{{ cookiecutter.project_slug }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -44,6 +44,7 @@
     ],
     "gitops_project": "{% if cookiecutter.deployment_strategy == 'gitops' %}{{ cookiecutter.project_slug }}-gitops{% else %}(none){% endif %}",
     "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
+    "docker_image": "{{ cookiecutter.cloud_project }}",
     "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "framework": [
@@ -54,6 +55,7 @@
         "Symfony",
         "TYPO3"
     ],
+    "application_hostname": "demo-application.local",
     "database": [
         "(none)",
         "Postgres",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -44,9 +44,10 @@
     ],
     "gitops_project": "{% if cookiecutter.deployment_strategy == 'gitops' %}{{ cookiecutter.project_slug }}-gitops{% else %}(none){% endif %}",
     "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
-    "docker_image": "{{ cookiecutter.cloud_project }}",
+    "docker_image": "{{ cookiecutter.project_slug }}",
     "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
+    "flux_ssh_known_hosts": "",
     "framework": [
         "(none)",
         "Django",
@@ -55,7 +56,6 @@
         "Symfony",
         "TYPO3"
     ],
-    "application_hostname": "demo-application.local",
     "database": [
         "(none)",
         "Postgres",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -44,6 +44,8 @@
     ],
     "gitops_project": "{% if cookiecutter.deployment_strategy == 'gitops' %}{{ cookiecutter.project_slug }}-gitops{% else %}(none){% endif %}",
     "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
+    "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
+    "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "framework": [
         "(none)",
         "Django",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -108,9 +108,9 @@ def prune_route_or_ingress():
     """
     app_manifests = Path('deployment') / 'application'
     base_path = app_manifests / 'base'
-    production_path = app_manifests / 'overlays' / 'production'
     development_path = app_manifests / 'overlays' / 'development'
     integration_path = app_manifests / 'overlays' / 'integration'
+    production_path = app_manifests / 'overlays' / 'production'
 
     if '{{ cookiecutter.cloud_platform }}' not in ['Rancher']:
         (base_path / 'ingress.yaml').unlink()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -109,10 +109,13 @@ def prune_route_or_ingress():
     app_manifests = Path('deployment') / 'application'
     base_path = app_manifests / 'base'
     production_path = app_manifests / 'overlays' / 'production'
+    development_path = app_manifests / 'overlays' / 'development'
+    integration_path = app_manifests / 'overlays' / 'integration'
 
     if '{{ cookiecutter.cloud_platform }}' not in ['Rancher']:
         (base_path / 'ingress.yaml').unlink()
-        (production_path / 'ingress.yaml').unlink()
+        (development_path / 'ingress-patch.yaml').unlink()
+        (integration_path / 'ingress-patch.yaml').unlink()
 
     if '{{ cookiecutter.cloud_platform }}' not in ['APPUiO']:
         (base_path / 'route.yaml').unlink()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -106,14 +106,17 @@ def prune_route_or_ingress():
     """
     Based on selected target cloud platform, remove the other unneeded files.
     """
-    base_path = Path('deployment') / 'application' / 'base'
+    app_manifests = Path('deployment') / 'application'
+    base_path = app_manifests / 'base'
+    production_path = app_manifests / 'overlays' / 'production'
 
     if '{{ cookiecutter.cloud_platform }}' in ['APPUiO']:
         (base_path / 'ingress.yaml').unlink()
+        (production_path / 'ingress.yaml').unlink()
     else:
         (base_path / 'route.yaml').unlink()
         (base_path / 'route-crd.yaml').unlink()
-        (base_path.parent / 'overlays' / 'production' / 'route.yaml').unlink()
+        (production_path / 'route.yaml').unlink()
 
 
 def flatten_folder_structure(folder, technology):

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -102,6 +102,19 @@ def prune_cronjob_style():
         shutil.rmtree(base_path / 'cronjob')
 
 
+def prune_route_or_ingress():
+    """
+    Based on selected target cloud platform, remove the other unneeded files.
+    """
+    base_path = Path('deployment') / 'application' / 'base'
+
+    if '{{ cookiecutter.cloud_platform }}' in ['APPUiO']:
+        (base_path / 'ingress.yaml').unlink()
+    else:
+        (base_path / 'route.yaml').unlink()
+        (base_path / 'route-crd.yaml').unlink()
+
+
 def flatten_folder_structure(folder, technology):
     """
     Integrate content from subfolders with special meaning (underscore
@@ -134,6 +147,7 @@ def set_up_deployment():
 
     LOG.info('Set up deployment configuration for %s project ...', framework)
     prune_cronjob_style()
+    prune_route_or_ingress()
     flatten_folder_structure(deployment, technology)
 
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -214,6 +214,7 @@ def move_appconfigs_to_gitops():
     for app_config in directories:
         target = Path('gitops') / 'deployment' / app_config.name
         merge_folder_into(app_config, target)
+    shutil.rmtree(Path('deployment'))
 
 
 def move_gitops_repo():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -183,6 +183,7 @@ def remove_temporary_files():
 
     if '{{ cookiecutter.database }}' == '(none)':
         shutil.rmtree('deployment/database')
+        shutil.rmtree('gitops/deployment/database')
 
 
 def merge_folder_into(src_dir, dest_dir):

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -113,6 +113,7 @@ def prune_route_or_ingress():
     else:
         (base_path / 'route.yaml').unlink()
         (base_path / 'route-crd.yaml').unlink()
+        (base_path.parent / 'overlays' / 'production' / 'route.yaml').unlink()
 
 
 def flatten_folder_structure(folder, technology):

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -110,10 +110,11 @@ def prune_route_or_ingress():
     base_path = app_manifests / 'base'
     production_path = app_manifests / 'overlays' / 'production'
 
-    if '{{ cookiecutter.cloud_platform }}' in ['APPUiO']:
+    if '{{ cookiecutter.cloud_platform }}' not in ['Rancher']:
         (base_path / 'ingress.yaml').unlink()
         (production_path / 'ingress.yaml').unlink()
-    else:
+
+    if '{{ cookiecutter.cloud_platform }}' not in ['APPUiO']:
         (base_path / 'route.yaml').unlink()
         (base_path / 'route-crd.yaml').unlink()
         (production_path / 'route.yaml').unlink()

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -39,7 +39,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 
     # run a specific set of tests (one or several)
     tox -e py37
-    tox -e flake8,py37
+    tox -e flake8,pylint
 
 .. code-block:: console
 
@@ -57,7 +57,8 @@ Examples:
 
 .. code-block:: console
 
-    tox -e py36 -- -vv --exitfirst
+    tox -e py38 -- -vv --exitfirst
+    tox -e behave -- --stop
     tox -e behave -- --format=pretty
     tox -e behave -- --tags=-docker
     tox -e flake8 -- --help

--- a/tests/acceptance/steps/given.py
+++ b/tests/acceptance/steps/given.py
@@ -85,4 +85,5 @@ def step_impl(context):
             'project_slug': project_slug,
             'framework': 'Django',
             'cronjobs': 'complex',
+            'cloud_platform': 'Rancher',
         })

--- a/tests/acceptance/steps/then.py
+++ b/tests/acceptance/steps/then.py
@@ -64,8 +64,8 @@ def step_impl(context):
         'ConfigMap',
         'CronJob',
         'Deployment',
+        'Ingress',
         'RoleBinding',
-        'Route',
         'Secret',
         'Service',
     ]

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -422,7 +422,13 @@ class TestCISetup:
 
         assert result.project.basename == project_slug
         assert result.project.isdir()
-        assert result.project.join('README.rst').isfile()
+        readme_file = result.project.join('README.rst')
+        assert readme_file.isfile()
+
+        readme_content = '\n'.join(readme_file.readlines(cr=False))
+        assert '\n\n\n' not in readme_content, \
+            f"Excessive newlines in README: {readme_file}\n" \
+            f"-------------\n{readme_content}"
 
         ci_service_conf = result.project.join(ci_service).readlines(cr=False)
         ci_service_content = '\n'.join(ci_service_conf)

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -213,12 +213,17 @@ class TestDeployment:
             'files_absent': [
                 'application/base/cronjob.yaml',
                 'application/base/cronjob',
+                'application/base/ingress.yaml',
+                'application/overlays/production/ingress.yaml',
+                'application/base/route.yaml',
+                'application/base/route-crd.yaml',
                 'application/overlays/production/route.yaml',
                 'database',
             ],
             'required_content': [],
             'absent_content': [
                 ('application/overlays/production/kustomization.yaml', [
+                    '- ingress.yaml',
                     '- route.yaml',
                 ]),
             ],

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -230,16 +230,18 @@ class TestDeployment:
             'cloud_platform': 'APPUiO',
             'strategy': 'shared',
             'cronjobs': '(none)',
-            'production_domain': '(automatic)',
+            'production_domain': 'appuio.example.com',
             'files_present': [
                 'application/base/route.yaml',
                 'application/base/route-crd.yaml',
+                'application/overlays/production/route.yaml',
                 'application/overlays/development',
                 'application/overlays/integration',
                 'application/overlays/production',
             ],
             'files_absent': [
                 'application/base/ingress.yaml',
+                'application/overlays/production/ingress.yaml',
                 'database',
             ],
             'required_content': [
@@ -275,7 +277,11 @@ class TestDeployment:
                     """),
                 ]),
             ],
-            'absent_content': [],
+            'absent_content': [
+                ('application/overlays/production/kustomization.yaml', [
+                    '- ingress.yaml',
+                ]),
+            ],
         }),
         ('Rancher', {
             'framework': 'SpringBoot',
@@ -284,9 +290,10 @@ class TestDeployment:
             'cloud_platform': 'Rancher',
             'strategy': 'shared',
             'cronjobs': '(none)',
-            'production_domain': '(automatic)',
+            'production_domain': 'rancher.example.com',
             'files_present': [
                 'application/base/ingress.yaml',
+                'application/overlays/production/ingress.yaml',
                 'application/overlays/development',
                 'application/overlays/integration',
                 'application/overlays/production',

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -214,7 +214,8 @@ class TestDeployment:
                 'application/base/cronjob.yaml',
                 'application/base/cronjob',
                 'application/base/ingress.yaml',
-                'application/overlays/production/ingress.yaml',
+                'application/overlays/development/ingress-patch.yaml',
+                'application/overlays/integration/ingress-patch.yaml',
                 'application/base/route.yaml',
                 'application/base/route-crd.yaml',
                 'application/overlays/production/route.yaml',
@@ -246,7 +247,8 @@ class TestDeployment:
             ],
             'files_absent': [
                 'application/base/ingress.yaml',
-                'application/overlays/production/ingress.yaml',
+                'application/overlays/development/ingress-patch.yaml',
+                'application/overlays/integration/ingress-patch.yaml',
                 'database',
             ],
             'required_content': [
@@ -283,8 +285,11 @@ class TestDeployment:
                 ]),
             ],
             'absent_content': [
-                ('application/overlays/production/kustomization.yaml', [
-                    '- ingress.yaml',
+                ('application/overlays/development/kustomization.yaml', [
+                    '- path: ingress-patch.yaml',
+                ]),
+                ('application/overlays/integration/kustomization.yaml', [
+                    '- path: ingress-patch.yaml',
                 ]),
             ],
         }),
@@ -298,7 +303,8 @@ class TestDeployment:
             'production_domain': 'rancher.example.com',
             'files_present': [
                 'application/base/ingress.yaml',
-                'application/overlays/production/ingress.yaml',
+                'application/overlays/development/ingress-patch.yaml',
+                'application/overlays/integration/ingress-patch.yaml',
                 'application/overlays/development',
                 'application/overlays/integration',
                 'application/overlays/production',
@@ -312,19 +318,23 @@ class TestDeployment:
             'required_content': [
                 ('application/base/ingress.yaml', [
                     dedent("""\
-                    apiVersion: networking.k8s.io/v1
+                    apiVersion: networking.k8s.io/v1beta1
                     kind: Ingress
                     metadata:
                       name: myproject
                     spec:
-                      port:
-                        targetPort: http
                       tls:
-                        insecureEdgeTerminationPolicy: Redirect
-                        termination: edge
-                      to:
-                        kind: Service
-                        name: application
+                        - hosts:
+                            - rancher.example.com
+                          secretName: application-tls-secret
+                      rules:
+                        - host: rancher.example.com
+                          http:
+                            paths:
+                              - backend:
+                                  serviceName: application
+                                  servicePort: http
+                                path: /
                     """),
                 ]),
                 ('application/base/ingress.yaml', ['  name: myproject']),

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -378,11 +378,8 @@ class TestDeployment:
                 f"File or folder {filename} in deployment should be absent."
 
         self.verify_app_folders_exist()
-        self.read_app_deployment_configs()
 
         if self.database != '(none)':
-            self.verify_db_folders_exist()
-            self.read_db_deployment_configs()
             self.ensure_db_app_stay_aligned()
 
         for filename, chunks in required_content:
@@ -439,6 +436,8 @@ class TestDeployment:
         """
         Read Kustomize configuration.
         """
+        self.verify_app_folders_exist()
+
         self.app_base_kustomize = \
             self.app_base.join('kustomization.yaml').readlines(cr=False)
         self.app_development_kustomize = \
@@ -452,6 +451,8 @@ class TestDeployment:
         """
         Read Kustomize configuration.
         """
+        self.verify_db_folders_exist()
+
         self.db_base_kustomize = \
             self.db_base.join('kustomization.yaml').readlines(cr=False)
         self.db_development_kustomize = \
@@ -466,6 +467,9 @@ class TestDeployment:
         Ensure that the top of the kustomization setups stays aligned
         across application and database deployment manifests.
         """
+        self.read_app_deployment_configs()
+        self.read_db_deployment_configs()
+
         assert self.app_base_kustomize[:3] == self.db_base_kustomize[:3]
 
         identical_lines = 8 if self.vcs_platform == 'GitLab.com' else 5

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -18,12 +18,19 @@ class TestDeployment:
             'framework': 'Django',
             'database': 'Postgres',
             'vcs_platform': 'GitLab.com',
+            'cloud_platform': '(none)',
             'strategy': 'dedicated',
             'cronjobs': '(none)',
             'production_domain': 'mydomain.com',
             'files_present': [
-                'application',
-                'database',
+                'application/base',
+                'application/overlays/development',
+                'application/overlays/integration',
+                'application/overlays/production',
+                'database/base',
+                'database/overlays/development',
+                'database/overlays/integration',
+                'database/overlays/production',
             ],
             'files_absent': [],
         }),
@@ -31,12 +38,15 @@ class TestDeployment:
             'framework': 'Symfony',
             'database': 'MySQL',
             'vcs_platform': 'Bitbucket.org',
+            'cloud_platform': '(none)',
             'strategy': 'shared',
             'cronjobs': '(none)',
             'production_domain': '(automatic)',
             'files_present': [
-                'application',
-                'database',
+                'application/base',
+                'application/overlays',
+                'database/base',
+                'database/overlays',
             ],
             'files_absent': [],
         }),
@@ -44,6 +54,7 @@ class TestDeployment:
             'framework': 'Flask',
             'database': 'MySQL',
             'vcs_platform': 'GitHub.com',
+            'cloud_platform': '(none)',
             'strategy': 'shared',
             'cronjobs': '(none)',
             'production_domain': '(automatic)',
@@ -60,11 +71,11 @@ class TestDeployment:
             'framework': 'SpringBoot',
             'database': 'MySQL',
             'vcs_platform': 'GitLab.com',
+            'cloud_platform': '(none)',
             'strategy': 'shared',
             'cronjobs': 'simple',
             'production_domain': '(automatic)',
             'files_present': [
-                'application',
                 'application/base/cronjob.yaml',
                 'database',
             ],
@@ -76,11 +87,11 @@ class TestDeployment:
             'framework': 'Flask',
             'database': 'Postgres',
             'vcs_platform': 'Bitbucket.org',
+            'cloud_platform': '(none)',
             'strategy': 'shared',
             'cronjobs': 'complex',
             'production_domain': '(automatic)',
             'files_present': [
-                'application',
                 'application/base/cronjob',
                 'database',
             ],
@@ -92,6 +103,7 @@ class TestDeployment:
             'framework': 'SpringBoot',
             'database': '(none)',
             'vcs_platform': 'GitLab.com',
+            'cloud_platform': '(none)',
             'strategy': 'shared',
             'cronjobs': '(none)',
             'production_domain': '(automatic)',
@@ -104,18 +116,60 @@ class TestDeployment:
                 'database',
             ],
         }),
+        ('APPUiO', {
+            'framework': 'SpringBoot',
+            'database': '(none)',
+            'vcs_platform': 'GitLab.com',
+            'cloud_platform': 'APPUiO',
+            'strategy': 'shared',
+            'cronjobs': '(none)',
+            'production_domain': '(automatic)',
+            'files_present': [
+                'application/base/route.yaml',
+                'application/base/route-crd.yaml',
+                'application/overlays/development',
+                'application/overlays/integration',
+                'application/overlays/production',
+            ],
+            'files_absent': [
+                'application/base/ingress.yaml',
+                'database',
+            ],
+        }),
+        ('Rancher', {
+            'framework': 'SpringBoot',
+            'database': '(none)',
+            'vcs_platform': 'GitLab.com',
+            'cloud_platform': 'Rancher',
+            'strategy': 'shared',
+            'cronjobs': '(none)',
+            'production_domain': '(automatic)',
+            'files_present': [
+                'application/base/ingress.yaml',
+                'application/overlays/development',
+                'application/overlays/integration',
+                'application/overlays/production',
+            ],
+            'files_absent': [
+                'application/base/route.yaml',
+                'application/base/route-crd.yaml',
+                'database',
+            ],
+        }),
     ]
 
     # pylint: disable=too-many-arguments
     def test_deploy_config(
-            self, cookies, framework, database, vcs_platform, strategy,
-            cronjobs, production_domain, files_present, files_absent):
+            self, cookies, framework, database, vcs_platform, cloud_platform,
+            strategy, cronjobs, production_domain, files_present,
+            files_absent):
         """
         Generate a deployment configuration and verify it is complete.
         """
         result = cookies.bake(extra_context={
             'project_slug': 'myproject',
             'vcs_platform': vcs_platform,
+            'cloud_platform': cloud_platform,
             'environment_strategy': strategy,
             'production_domain': production_domain,
             'framework': framework,
@@ -154,7 +208,7 @@ class TestDeployment:
             self.ensure_db_app_stay_aligned()
 
         self.verify_gitlab_annotations()
-        self.verify_route_setup()
+        # self.verify_route_setup()
 
     def verify_app_folders_exist(self):
         """

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -36,7 +36,7 @@ class TestGitops:
             'files_absent': [
                 'bitbucket/gitops/',
                 'bitbucket-gitops/_/',
-                'bitbucket-gitops/deployment/database/base/kustomization.yaml',
+                'bitbucket-gitops/deployment/database/',
                 'bitbucket-gitops/docker-compose.yml',
                 'bitbucket-gitops/Dockerfile',
             ],
@@ -162,7 +162,7 @@ class TestGitops:
             'files_absent': [
                 'codeship/gitops/',
                 'codeship-gitops/_/',
-                'codeship-gitops/deployment/database/base/kustomization.yaml',
+                'codeship-gitops/deployment/database/',
                 'codeship-gitops/docker-compose.yml',
                 'codeship-gitops/Dockerfile',
             ],
@@ -201,7 +201,7 @@ class TestGitops:
             'files_absent': [
                 'gitlab/gitops/',
                 'gitlab-gitops/_/',
-                'gitlab-gitops/deployment/database/base/kustomization.yaml',
+                'gitlab-gitops/deployment/database/',
                 'gitlab-gitops/docker-compose.yml',
                 'gitlab-gitops/Dockerfile',
             ],

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -19,6 +19,7 @@ class TestGitops:
             'framework': 'SpringBoot',
             'ci_service': 'bitbucket-pipelines.yml',
             'cloud_platform': 'APPUiO',
+            'docker_registry': "registry.appuio.ch",
             'files_present': [
                 'bitbucket/.git/config',
                 'bitbucket/.gitignore',
@@ -40,7 +41,6 @@ class TestGitops:
                 'bitbucket-gitops/docker-compose.yml',
                 'bitbucket-gitops/Dockerfile',
             ],
-            'docker_registry': 'registry.appuio.example',
             'required_content': [
                 ('bitbucket/bitbucket-pipelines.yml', [
                     indent2("""
@@ -137,13 +137,14 @@ class TestGitops:
                       - parallel: *checks
                     """),
                 ]),
-                ('bitbucket-gitops/deployment/application/overlays/development/kustomization.yaml', [
-                    dedent("""
+                ('bitbucket-gitops/deployment/application/overlays/' \
+                    'development/kustomization.yaml', [
+                        dedent("""
                     images:
                     - name: IMAGE
                       newName: registry.appuio.ch/bitbucket/bitbucket:latest
                     """),
-                ])
+                ]),  # noqa
             ],
         }),
         ('Codeship', {
@@ -186,13 +187,14 @@ class TestGitops:
                 command: /kubeval --strict --ignore-missing-schemas **/*.yaml
                     """),
                 ]),
-                ('codeship-gitops/deployment/application/overlays/development/kustomization.yaml', [
-                    dedent("""
-                    images:
-                    - name: IMAGE
-                      newName: registry.rancher.example/codeship/codeship:latest
-                    """),
-                ])
+                ('codeship-gitops/deployment/application/overlays/'
+                    'development/kustomization.yaml', [
+                        dedent("""
+                images:
+                - name: IMAGE
+                  newName: registry.rancher.example/codeship/codeship:latest
+                """),
+                ]),  # noqa
             ],
         }),
         ('GitLab', {
@@ -278,13 +280,14 @@ class TestGitops:
                       - /kubeval --strict --ignore-missing-schemas **/*.yaml
                     """),
                 ]),
-                ('gitlab-gitops/deployment/application/overlays/development/kustomization.yaml', [
-                    dedent("""
+                ('gitlab-gitops/deployment/application/overlays/'
+                    'development/kustomization.yaml', [
+                        dedent("""
                     images:
                     - name: IMAGE
                       newName: registry.rancher.example/gitlab/gitlab:latest
                     """),
-                ])
+                ]),  # noqa
             ],
         }),
     ]

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -40,6 +40,7 @@ class TestGitops:
                 'bitbucket-gitops/docker-compose.yml',
                 'bitbucket-gitops/Dockerfile',
             ],
+            'docker_registry': 'registry.appuio.example',
             'required_content': [
                 ('bitbucket/bitbucket-pipelines.yml', [
                     indent2("""
@@ -136,6 +137,13 @@ class TestGitops:
                       - parallel: *checks
                     """),
                 ]),
+                ('bitbucket-gitops/deployment/application/overlays/development/kustomization.yaml', [
+                    dedent("""
+                    images:
+                    - name: IMAGE
+                      newName: registry.appuio.ch/bitbucket/bitbucket:latest
+                    """),
+                ])
             ],
         }),
         ('Codeship', {
@@ -143,6 +151,7 @@ class TestGitops:
             'framework': 'SpringBoot',
             'ci_service': 'codeship-steps.yml',
             'cloud_platform': 'Rancher',
+            'docker_registry': "registry.rancher.example",
             'files_present': [
                 'codeship/.git/config',
                 'codeship/.gitignore',
@@ -177,6 +186,13 @@ class TestGitops:
                 command: /kubeval --strict --ignore-missing-schemas **/*.yaml
                     """),
                 ]),
+                ('codeship-gitops/deployment/application/overlays/development/kustomization.yaml', [
+                    dedent("""
+                    images:
+                    - name: IMAGE
+                      newName: registry.rancher.example/codeship/codeship:latest
+                    """),
+                ])
             ],
         }),
         ('GitLab', {
@@ -184,6 +200,7 @@ class TestGitops:
             'framework': 'SpringBoot',
             'ci_service': '.gitlab-ci.yml',
             'cloud_platform': 'Rancher',
+            'docker_registry': "registry.rancher.example",
             'files_present': [
                 'gitlab/.git/config',
                 'gitlab/.gitignore',
@@ -261,14 +278,21 @@ class TestGitops:
                       - /kubeval --strict --ignore-missing-schemas **/*.yaml
                     """),
                 ]),
+                ('gitlab-gitops/deployment/application/overlays/development/kustomization.yaml', [
+                    dedent("""
+                    images:
+                    - name: IMAGE
+                      newName: registry.rancher.example/gitlab/gitlab:latest
+                    """),
+                ])
             ],
         }),
     ]
 
     # pylint: disable=no-self-use,too-many-arguments,too-many-locals
     def test_gitops(self, cookies, project_slug, framework, ci_service,
-                    cloud_platform, files_present, files_absent,
-                    required_content):
+                    cloud_platform, docker_registry, files_present,
+                    files_absent, required_content):
         """
         Generate a project with a specific deployment strategy and verify
         it is complete and working.
@@ -279,6 +303,7 @@ class TestGitops:
             'framework': framework,
             'ci_service': ci_service,
             'cloud_platform': cloud_platform,
+            'docker_registry': docker_registry,
         })
 
         assert result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands = pytest {posargs}
 description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
-    py3clean {toxinidir}
+    pyclean {toxinidir}
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-projects
 whitelist_externals =
     rm

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -47,8 +47,7 @@ Initial Setup
 
         grep -A2 limits deployment/*/*/*yaml
         grep -A2 requests deployment/*/*/*yaml
-
-{% if cookiecutter.cloud_platform in ['APPUiO'] -%}
+{% if cookiecutter.cloud_platform in ['APPUiO'] %}
 #. With the commands below, create a service account from your terminal
    (logging in to your cluster first), grant permissions to push images
    and apply configurations, and get the service account's token value:
@@ -63,10 +62,10 @@ Initial Setup
         oc -n {{ cookiecutter.cloud_project }} create sa {{ cookiecutter.automation_user }}
         oc -n {{ cookiecutter.cloud_project }} policy add-role-to-user admin -z {{ cookiecutter.automation_user }}
         oc -n {{ cookiecutter.cloud_project }} sa get-token {{ cookiecutter.automation_user }}
-{%- endif %}
-{% elif cookiecutter.cloud_platform in ['Rancher'] -%}
+{%- endif -%}
+{%- elif cookiecutter.cloud_platform in ['Rancher'] %}
 #. Create a service account called "{{ cookiecutter.automation_user }}", determine its token.
-{%- endif %}
+{%- endif -%}
 {%- if cookiecutter.ci_service == 'bitbucket-pipelines.yml' %}
 
 #. Note down service account token and your cluster's URL, and

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -48,7 +48,7 @@ stages:
     IMAGE: ${REGISTRY}/${TARGET}/{{ cookiecutter.project_slug }}
     TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
   before_script:
-  - docker login -u gitlab-ci -p ${KUBE_TOKEN} ${REGISTRY}
+  - docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
   - docker pull "${IMAGE}:latest" || true
   script:
   - docker build . -t "${IMAGE}:${CI_COMMIT_SHA}"

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -45,8 +45,8 @@ stages:
   - name: docker:dind
   variables:
     GIT_DEPTH: 7
-    IMAGE: ${REGISTRY}/${TARGET}/{{ cookiecutter.project_slug }}
-    TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
+    IMAGE: ${REGISTRY}/${TARGET}
+    TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}/{{ cookiecutter.docker_image }}
   before_script:
   - docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
   - docker pull "${IMAGE}:latest" || true

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
@@ -14,7 +14,7 @@ definitions:
       TARGET={{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
       IMAGE="${REGISTRY}/${TARGET}/{{ cookiecutter.project_slug }}"
     - &docker-login
-      docker login -u bitbucket-pipelines -p ${KUBE_TOKEN} ${REGISTRY}
+      docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
     - &build-image
       docker build . -t "${IMAGE}:${BITBUCKET_COMMIT}"
     - &tag-image
@@ -43,7 +43,7 @@ definitions:
       DATABASE_USER={{ cookiecutter.project_slug.replace('-', '_') }}
       {%- endif %}
     - &docker-login
-      docker login -u bitbucket-pipelines -p ${KUBE_TOKEN} ${REGISTRY}
+      docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
     - &build-image
       docker build . -t "${IMAGE}:${BITBUCKET_COMMIT}"
                      -t "${IMAGE}:latest"

--- a/{{cookiecutter.project_slug}}/_/frameworks/SpringBoot/build.gradle
+++ b/{{cookiecutter.project_slug}}/_/frameworks/SpringBoot/build.gradle
@@ -3,8 +3,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.3.RELEASE")
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.3.3.RELEASE"
         classpath 'org.springframework:springloaded:1.2.8.RELEASE'
+        classpath 'org.springframework.boot:spring-boot-starter-actuator'
     }
 }
 

--- a/{{cookiecutter.project_slug}}/_/frameworks/SpringBoot/pom.xml
+++ b/{{cookiecutter.project_slug}}/_/frameworks/SpringBoot/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
@@ -39,7 +39,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 
     # run a specific set of tests (one or several)
     tox -e py37
-    tox -e flake8,py37
+    tox -e flake8,pylint
 
 .. code-block:: console
 
@@ -57,7 +57,8 @@ Examples:
 
 .. code-block:: console
 
-    tox -e py36 -- -vv --exitfirst
+    tox -e py38 -- -vv --exitfirst
+    tox -e behave -- --stop
     tox -e behave -- --format=pretty
     tox -e behave -- --tags=-docker
     tox -e flake8 -- --help

--- a/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      component: application
   template:
     metadata:
       labels:
@@ -13,7 +16,7 @@ spec:
       {%- if cookiecutter.database != '(none)' %}
       initContainers:
       - name: wait-for-database
-        image: IMAGE
+        image: python:latest
         command: {% if cookiecutter.framework == 'Django' -%}
             ["python", "manage.py", "wait_for_database"]
           {%- else -%}
@@ -27,22 +30,34 @@ spec:
       {%- endif %}
       containers:
       - name: {{ cookiecutter.framework|lower }}
-        image: IMAGE
+        image: {{ cookiecutter.docker_registry }}/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}/{{ cookiecutter.docker_image}}:latest
         ports:
         - name: uwsgi
-          containerPort: 8000
+          containerPort: {%- if cookiecutter.framework == 'SpringBoot' %} 8080 {%- else  %} 8000 {%- endif %}
         envFrom:
         - configMapRef:
             name: application
         - secretRef:
             name: application
         livenessProbe:
+          {%- if cookiecutter.framework == 'SpringBoot' %}
+          httpGet:
+            path: /actuator/health/liveness
+            port: uwsgi
+          {%- else %}
           tcpSocket:
             port: uwsgi
+          {%- endif %}
           initialDelaySeconds: 13
         readinessProbe:
+          {%- if cookiecutter.framework == 'SpringBoot' %}
+          httpGet:
+            path: /actuator/health/readiness
+            port: uwsgi
+          {%- else %}
           tcpSocket:
             port: uwsgi
+          {%- endif %}
           initialDelaySeconds: 9
         resources:
           requests:
@@ -55,8 +70,9 @@ spec:
           preStop:
             exec:
               command: ["sleep", "20"]
+      {%- if cookiecutter.framework != 'SpringBoot' %}
       - name: nginx
-        image: IMAGE
+        image: nginx:latest
         command: ["nginx"]
         ports:
         - name: http
@@ -82,6 +98,7 @@ spec:
           preStop:
             exec:
               command: ["sleep", "20"]
+      {%- endif %}
       restartPolicy: Always
       affinity:
         podAntiAffinity:

--- a/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       {%- if cookiecutter.database != '(none)' %}
       initContainers:
       - name: wait-for-database
-        image: python:latest
+        image: IMAGE
         command: {% if cookiecutter.framework == 'Django' -%}
             ["python", "manage.py", "wait_for_database"]
           {%- else -%}
@@ -30,7 +30,7 @@ spec:
       {%- endif %}
       containers:
       - name: {{ cookiecutter.framework|lower }}
-        image: {{ cookiecutter.docker_registry }}/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}/{{ cookiecutter.docker_image}}:latest
+        image: IMAGE
         ports:
         - name: uwsgi
           containerPort: {%- if cookiecutter.framework == 'SpringBoot' %} 8080 {%- else  %} 8000 {%- endif %}
@@ -72,7 +72,7 @@ spec:
               command: ["sleep", "20"]
       {%- if cookiecutter.framework != 'SpringBoot' %}
       - name: nginx
-        image: nginx:latest
+        image: IMAGE
         command: ["nginx"]
         ports:
         - name: http

--- a/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         image: IMAGE
         ports:
         - name: uwsgi
-          containerPort: {%- if cookiecutter.framework == 'SpringBoot' %} 8080 {%- else  %} 8000 {%- endif %}
+          containerPort: {% if cookiecutter.framework == 'SpringBoot' %}8080{% else %}8000{% endif %}
         envFrom:
         - configMapRef:
             name: application
@@ -70,7 +70,7 @@ spec:
           preStop:
             exec:
               command: ["sleep", "20"]
-      {%- if cookiecutter.framework != 'SpringBoot' %}
+      {%- if cookiecutter.framework not in ['SpringBoot'] %}
       - name: nginx
         image: IMAGE
         command: ["nginx"]

--- a/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
@@ -1,13 +1,17 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ cookiecutter.project_slug }}
 spec:
-  port:
-    targetPort: http
   tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-  to:
-    kind: Service
-    name: application
+    - hosts:
+        - {{ cookiecutter.application_hostname }}
+      secretName: application-tls-secret
+  rules:
+    - host: {{ cookiecutter.application_hostname }}
+      http:
+        paths:
+          - backend:
+              serviceName: application
+              servicePort: http
+            path: /

--- a/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - {{ cookiecutter.application_hostname }}
+        - {{ cookiecutter.production_domain }}
       secretName: application-tls-secret
   rules:
-    - host: {{ cookiecutter.application_hostname }}
+    - host: {{ cookiecutter.production_domain }}
       http:
         paths:
           - backend:

--- a/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ cookiecutter.project_slug }}
+spec:
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: application

--- a/{{cookiecutter.project_slug}}/deployment/application/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/kustomization.yaml
@@ -10,14 +10,21 @@ configMapGenerator:
 bases:
 - cronjob
 {%- endif %}
+{%- if cookiecutter.cloud_platform in ['APPUiO'] %}
 crds:
 - route-crd.yaml
+{%- endif %}
 resources:
 {%- if cookiecutter.cronjobs == 'simple' %}
 - cronjob.yaml
 {%- endif %}
 - deployment.yaml
+{%- if cookiecutter.cloud_platform not in ['APPUiO'] %}
+- ingress.yaml
+{%- endif %}
 - rolebinding.yaml
+{%- if cookiecutter.cloud_platform in ['APPUiO'] %}
 - route.yaml
+{%- endif %}
 - secret.yaml
 - service.yaml

--- a/{{cookiecutter.project_slug}}/deployment/application/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/base/kustomization.yaml
@@ -19,7 +19,7 @@ resources:
 - cronjob.yaml
 {%- endif %}
 - deployment.yaml
-{%- if cookiecutter.cloud_platform not in ['APPUiO'] %}
+{%- if cookiecutter.cloud_platform in ['Rancher'] %}
 - ingress.yaml
 {%- endif %}
 - rolebinding.yaml

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/development/ingress-patch.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/development/ingress-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/tls/0/hosts/0
+  value: dev.{{ cookiecutter.production_domain }}
+- op: replace
+  path: /spec/rules/0/host
+  value: dev.{{ cookiecutter.production_domain }}

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/development/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/development/kustomization.yaml
@@ -17,3 +17,17 @@ resources:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml
+{%- if cookiecutter.cloud_platform == 'Rancher' %}
+patches:
+- path: ingress-patch.yaml
+  target:
+    group: networking.k8s.io
+    version: v1beta1
+    kind: Ingress
+    name: {{ cookiecutter.project_slug }}
+{%- endif %}
+{%- if cookiecutter.deployment_strategy == 'gitops' %}
+images:
+- name: IMAGE
+  newName: {{ cookiecutter.docker_registry }}/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}/{{ cookiecutter.docker_image}}:latest
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/integration/ingress-patch.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/integration/ingress-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/tls/0/hosts/0
+  value: int.{{ cookiecutter.production_domain }}
+- op: replace
+  path: /spec/rules/0/host
+  value: int.{{ cookiecutter.production_domain }}

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/integration/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/integration/kustomization.yaml
@@ -13,5 +13,14 @@ configMapGenerator:
   behavior: merge
   envs:
   - application.env
+{%- if cookiecutter.cloud_platform == 'Rancher' %}
+patches:
+- path: ingress-patch.yaml
+  target:
+    group: networking.k8s.io
+    version: v1beta1
+    kind: Ingress
+    name: {{ cookiecutter.project_slug }}
+{%- endif %}
 resources:
 - ../../base

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/production/ingress.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/production/ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+  name: {{ cookiecutter.project_slug }}
+spec:
+  host: {{ cookiecutter.production_domain|replace('(automatic)', 'example.com') }}

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/production/ingress.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/production/ingress.yaml
@@ -1,8 +1,0 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/tls-acme: "true"
-  name: {{ cookiecutter.project_slug }}
-spec:
-  host: {{ cookiecutter.production_domain|replace('(automatic)', 'example.com') }}

--- a/{{cookiecutter.project_slug}}/deployment/application/overlays/production/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/deployment/application/overlays/production/kustomization.yaml
@@ -18,5 +18,9 @@ resources:
 patchesStrategicMerge:
 - deployment.yaml
 {%- if cookiecutter.production_domain != '(automatic)' %}
+  {%- if cookiecutter.cloud_platform in ['APPUiO'] %}
 - route.yaml
+  {%- elif cookiecutter.cloud_platform in ['Rancher'] %}
+- ingress.yaml
+  {%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/gitops/README.rst
+++ b/{{cookiecutter.project_slug}}/gitops/README.rst
@@ -25,17 +25,21 @@ you're developing.  Log output will be displayed in the terminal, as usual.
 
 For running tests, linting, security checks, etc. see instructions in the
 `tests/ <tests/README.rst>`_ folder.
+{%- if cookiecutter.cloud_platform != '(none)' %}
 
-{% if cookiecutter.cloud_platform == 'APPUiO' -%}
 Initial Setup
 ^^^^^^^^^^^^^
 
 {% if cookiecutter.environment_strategy == 'dedicated' -%}
-#. Create a *production*, *integration* and *development* project at the
+#. Create a *production*, *integration* and *development* project
 {%- else -%}
-#. Create a project at the
+#. Create a project
 {%- endif %}
-   `VSHN Control Panel <https://control.vshn.net/openshift/projects/appuio%20public>`_.
+{%- if cookiecutter.cloud_platform in ['APPUiO'] %}
+   at the `VSHN Control Panel <https://control.vshn.net/openshift/projects/appuio%20public>`_.
+{%- elif cookiecutter.cloud_platform in ['Rancher'] %}
+   with Rancher.
+{%- endif %}
    For quota sizing consider roughly the sum of ``limits`` of all
    resources (must be strictly greater than the sum of ``requests``):
 
@@ -44,23 +48,26 @@ Initial Setup
         grep -A2 limits deployment/*/*/*yaml
         grep -A2 requests deployment/*/*/*yaml
 
+{% if cookiecutter.cloud_platform in ['APPUiO'] -%}
 #. With the commands below, create a service account from your terminal
    (logging in to your cluster first), grant permissions to push images
    and apply configurations, and get the service account's token value:
    (`APPUiO docs <https://docs.appuio.ch/en/latest/services/webserver/50_pushing_to_appuio.html>`_)
 
    .. code-block:: console
-{% set service_account = cookiecutter.ci_service|replace('.yml', '')|replace('.', '')|replace('-steps', '')|replace('travis', 'travis-ci') %}
-{%- if cookiecutter.environment_strategy == 'dedicated' %}
-        oc -n {{ cookiecutter.cloud_project }}-production create sa {{ service_account }}
-        oc -n {{ cookiecutter.cloud_project }}-production policy add-role-to-user admin -z {{ service_account }}
-        oc -n {{ cookiecutter.cloud_project }}-production sa get-token {{ service_account }}
+{% if cookiecutter.environment_strategy == 'dedicated' %}
+        oc -n {{ cookiecutter.cloud_project }}-production create sa {{ cookiecutter.automation_user }}
+        oc -n {{ cookiecutter.cloud_project }}-production policy add-role-to-user admin -z {{ cookiecutter.automation_user }}
+        oc -n {{ cookiecutter.cloud_project }}-production sa get-token {{ cookiecutter.automation_user }}
 {%- else %}
-        oc -n {{ cookiecutter.cloud_project }} create sa {{ service_account }}
-        oc -n {{ cookiecutter.cloud_project }} policy add-role-to-user admin -z {{ service_account }}
-        oc -n {{ cookiecutter.cloud_project }} sa get-token {{ service_account }}
+        oc -n {{ cookiecutter.cloud_project }} create sa {{ cookiecutter.automation_user }}
+        oc -n {{ cookiecutter.cloud_project }} policy add-role-to-user admin -z {{ cookiecutter.automation_user }}
+        oc -n {{ cookiecutter.cloud_project }} sa get-token {{ cookiecutter.automation_user }}
 {%- endif %}
-{%- if service_account == 'bitbucket-pipelines' %}
+{% elif cookiecutter.cloud_platform in ['Rancher'] -%}
+#. Create a service account called "{{ cookiecutter.automation_user }}", determine its token.
+{%- endif %}
+{%- if cookiecutter.ci_service == 'bitbucket-pipelines.yml' %}
 
 #. Note down service account token and your cluster's URL, and
 
@@ -73,7 +80,8 @@ Initial Setup
      to integrate with your container platform:
 
      - ``KUBE_TOKEN``
-     - ``KUBE_URL``
+     - ``KUBE_URL``{% if cookiecutter.cloud_platform not in ['APPUiO'] %}
+     - ``REGISTRY_PASSWORD`` (for image registry account {{ cookiecutter.registry_user }}){% endif %}
 
 #. Rename the default deployment environments at
 
@@ -84,44 +92,52 @@ Initial Setup
 
    - *Test* ➜ *Development*
    - *Staging* ➜ *Integration*
-{%- elif service_account == 'gitlab-ci' %}
+{%- elif cookiecutter.ci_service == '.gitlab-ci.yml' %}
 
 #. Use the service account token to configure the
    `Kubernetes integration <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/clusters>`_
    of your GitLab project: (`GitLab docs <https://docs.gitlab.com/ee/user/project/clusters/>`_)
 
-   - Operations > Kubernetes > "APPUiO" > Kubernetes cluster details > Service Token
+   - Operations > Kubernetes > "{{ cookiecutter.cloud_platform }}" > Kubernetes cluster details > Service Token
 
    and ensure the following values are set in the cluster details:
 
    - RBAC-enabled cluster: *(checked)*
    - GitLab-managed cluster: *(unchecked)*
    - Project namespace: {% if cookiecutter.environment_strategy == 'shared' %}"{{ cookiecutter.cloud_project }}"{% else %}*(empty)*{% endif %}
+{%- if cookiecutter.cloud_platform not in ['APPUiO'] %}
+
+#. At `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
+   add the password for your "{{ cookiecutter.registry_user }}" account to allow the pipeline access your image registry with
+
+   - ``REGISTRY_PASSWORD``
+{%- endif %}
 {%- endif %}
 {%- if cookiecutter.environment_strategy == 'dedicated' %}
-
+{% if cookiecutter.cloud_platform in ['APPUiO'] %}
 #. Grant the service account permissions on the *development* and *integration*
    projects:
 
    .. code-block:: console
 
         oc -n {{ cookiecutter.cloud_project }}-integration policy add-role-to-user \
-          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ service_account }}
+          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ cookiecutter.automation_user }}
         oc -n {{ cookiecutter.cloud_project }}-development policy add-role-to-user \
-          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ service_account }}
+          admin system:serviceaccount:{{ cookiecutter.cloud_project }}-production:{{ cookiecutter.automation_user }}
 {%- endif %}
 {%- endif %}
-{%- if cookiecutter.monitoring == 'Sentry' %}
+{%- endif %}
+{%- if cookiecutter.monitoring == 'Sentry' and cookiecutter.ci_service == '.gitlab-ci.yml' %}
 
 Integrate External Tools
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 :Sentry:
   - Add environment variable ``SENTRY_DSN`` in
-    `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`_
+    `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
   - Delete secrets in your namespace and run a deployment (to recreate them)
-  - Configure `Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/error_tracking>`_
-    in `Settings > Operations > Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/operations>`_
+  - Configure `Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/error_tracking>`__
+    in `Settings > Operations > Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/operations>`__
 {%- endif %}
 
 Working with Docker
@@ -213,7 +229,7 @@ Credits
 ^^^^^^^
 
 Made with ♥ by `Painless Continuous Delivery`_ Cookiecutter. This project was
-generated via:
+generated by:
 
 .. code-block:: console
 
@@ -228,7 +244,11 @@ generated via:
         cloud_account="{{ cookiecutter.cloud_account }}" \
         cloud_project="{{ cookiecutter.cloud_project }}" \
         environment_strategy="{{ cookiecutter.environment_strategy }}" \
+        deployment_strategy="{{ cookiecutter.deployment_strategy }}" \
+        gitops_project="{{ cookiecutter.gitops_project }}" \
         docker_registry="{{ cookiecutter.docker_registry }}" \
+        registry_user="{{ cookiecutter.registry_user }}" \
+        automation_user="{{ cookiecutter.automation_user }}" \
         framework="{{ cookiecutter.framework }}" \
         database="{{ cookiecutter.database }}" \
         cronjobs="{{ cookiecutter.cronjobs }}" \

--- a/{{cookiecutter.project_slug}}/gitops/README.rst
+++ b/{{cookiecutter.project_slug}}/gitops/README.rst
@@ -47,8 +47,7 @@ Initial Setup
 
         grep -A2 limits deployment/*/*/*yaml
         grep -A2 requests deployment/*/*/*yaml
-
-{% if cookiecutter.cloud_platform in ['APPUiO'] -%}
+{% if cookiecutter.cloud_platform in ['APPUiO'] %}
 #. With the commands below, create a service account from your terminal
    (logging in to your cluster first), grant permissions to push images
    and apply configurations, and get the service account's token value:
@@ -63,10 +62,10 @@ Initial Setup
         oc -n {{ cookiecutter.cloud_project }} create sa {{ cookiecutter.automation_user }}
         oc -n {{ cookiecutter.cloud_project }} policy add-role-to-user admin -z {{ cookiecutter.automation_user }}
         oc -n {{ cookiecutter.cloud_project }} sa get-token {{ cookiecutter.automation_user }}
-{%- endif %}
-{% elif cookiecutter.cloud_platform in ['Rancher'] -%}
+{%- endif -%}
+{%- elif cookiecutter.cloud_platform in ['Rancher'] %}
 #. Create a service account called "{{ cookiecutter.automation_user }}", determine its token.
-{%- endif %}
+{%- endif -%}
 {%- if cookiecutter.ci_service == 'bitbucket-pipelines.yml' %}
 
 #. Note down service account token and your cluster's URL, and

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/.flux.yaml
@@ -1,0 +1,5 @@
+version: 1
+patchUpdated:
+  generators:
+    - command: kustomize build .
+  patchFile: flux-patch.yaml

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/.flux.yaml
@@ -1,5 +1,0 @@
-version: 1
-patchUpdated:
-  generators:
-    - command: kustomize build .
-  patchFile: flux-patch.yaml

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/.flux.yaml
@@ -1,5 +1,7 @@
 version: 1
 patchUpdated:
   generators:
+    - command: sops -d --output secrets.dec.yaml secrets.yaml
     - command: kustomize build .
+    - command: rm secret.dec.yaml
   patchFile: flux-patch.yaml

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/flux-patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: application
+spec:
+  strategy:
+    type: Recreate

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/development/flux-patch.yaml
@@ -2,7 +2,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    flux.weave.works/automated: "true"
   name: application
+  namespace: springbootdemo-development
 spec:
-  strategy:
-    type: Recreate
+  selector:
+    matchLabels:
+      component: application
+  template:
+    spec:
+      $setElementOrder/containers:
+      - name: springboot
+      containers:
+        - name: springboot
+          image: docker-push.crb.ch/springbootdemo:v1.0.0

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/.flux.yaml
@@ -1,0 +1,7 @@
+version: 1
+patchUpdated:
+  generators:
+    - command: sops -d --output secrets.dec.yaml secrets.yaml
+    - command: kustomize build .
+    - command: rm secret.dec.yaml
+  patchFile: flux-patch.yaml

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/flux-patch.yaml
@@ -1,0 +1,3 @@
+---
+apiVersion: apps/v1
+kind: Deployment

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/integration/flux-patch.yaml
@@ -1,3 +1,19 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+metadata:
+  annotations:
+    flux.weave.works/automated: "true"
+  name: application
+  namespace: springbootdemo-development
+spec:
+  selector:
+    matchLabels:
+      component: application
+  template:
+    spec:
+      $setElementOrder/containers:
+      - name: springboot
+      containers:
+        - name: springboot
+          image: docker-push.crb.ch/springbootdemo:v1.0.0

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/.flux.yaml
@@ -1,0 +1,7 @@
+version: 1
+patchUpdated:
+  generators:
+    - command: sops -d --output secrets.dec.yaml secrets.yaml
+    - command: kustomize build .
+    - command: rm secret.dec.yaml
+  patchFile: flux-patch.yaml

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/flux-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: application
+spec:
+  replicas: 2

--- a/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/flux-patch.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/application/overlays/production/flux-patch.yaml
@@ -2,6 +2,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    flux.weave.works/automated: "true"
   name: application
+  namespace: springbootdemo-development
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      component: application
+  template:
+    spec:
+      $setElementOrder/containers:
+      - name: springboot
+      containers:
+        - name: springboot
+          image: docker-push.crb.ch/springbootdemo:v1.0.0

--- a/{{cookiecutter.project_slug}}/gitops/deployment/database/.flux.yaml
+++ b/{{cookiecutter.project_slug}}/gitops/deployment/database/.flux.yaml
@@ -1,0 +1,1 @@
+# placeholder for future database manifest implementation


### PR DESCRIPTION
The changes herein will allow to generate a [vanilla Kubernetes](https://kubernetes.io/) deployment configuration, one that is usable with a [Rancher cluster](https://rancher.com/) (as opposed to [OpenShift v3](https://www.openshift.com/), which was exclusively targeted / supported until now).