### PR TITLE
Configure GitLab environment URLs (GitOps), reduce review app TTL (pipeline)

### DIFF
--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -264,7 +264,7 @@ class TestCISetup:
                 '    popd',
                 'stop_review:',
                 '  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}',  # noqa
-                '    auto_stop_in: 18 hours',
+                '    auto_stop_in: 12 hours',
                 '    DATABASE_HOST: postgres-${CI_ENVIRONMENT_NAME}',
                 '    DATABASE_HOST: postgres-review-mr${CI_MERGE_REQUEST_IID}',
                 '    DATABASE_NAME: myproject',
@@ -327,7 +327,7 @@ class TestCISetup:
                 '    popd',
                 'stop_review:',
                 '  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}',  # noqa
-                '    auto_stop_in: 18 hours',
+                '    auto_stop_in: 12 hours',
                 '    DATABASE_HOST: postgres',
                 '    DATABASE_HOST: postgres-review-mr${CI_MERGE_REQUEST_IID}',
                 '    DATABASE_NAME: myproject',

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -56,8 +56,10 @@ stages:
 
 {% if cookiecutter.deployment_strategy == 'gitops' -%}
 .tag-image:
-  extends: .build
   stage: deploy
+  extends: .build
+  environment:
+    url: "${KUBE_URL}/console/project/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/browse/images"
   script:
   - docker tag "${IMAGE}:${CI_COMMIT_SHA}" "${IMAGE}:${IMAGE_TAG}"
   - docker push "${IMAGE}"

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -32,7 +32,7 @@ review:
   environment:
     name: development
     on_stop: stop_review
-    auto_stop_in: 18 hours
+    auto_stop_in: 12 hours
   variables:
     SUFFIX: -review-mr${CI_MERGE_REQUEST_IID}
     LABEL: {{ cookiecutter.project_slug }}-review-mr${CI_MERGE_REQUEST_IID}


### PR DESCRIPTION
Two almost cosmetic changes to the pipeline setup

- Point GitLab environment URLs to images for GitOps – _nice integration of target image registry in GitLab (environments)_
- Reduce TTL (automatic teardown) for review apps – _this will reduce resource consumption by default and should motivate to merge MRs faster_