### PR TITLE
GitOps: Use variable targets for pushing images

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -45,8 +45,8 @@ stages:
   - name: docker:dind
   variables:
     GIT_DEPTH: 7
-    IMAGE: ${REGISTRY}/${TARGET}
-    TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}/{{ cookiecutter.docker_image }}
+    TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}
+    IMAGE: ${REGISTRY}/${TARGET}/{{ cookiecutter.docker_image }}
   before_script:
   - docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
   - docker pull "${IMAGE}:latest" || true
@@ -60,9 +60,13 @@ stages:
   extends: .build
   environment:
     url: "${KUBE_URL}/console/project/{{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}/browse/images"
+  variables:
+    SOURCE: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-development{% endif %}
+    TARGET: {{ cookiecutter.cloud_project }}{% if cookiecutter.environment_strategy == 'dedicated' %}-${CI_ENVIRONMENT_NAME}{% endif %}
   script:
-  - docker tag "${IMAGE}:${CI_COMMIT_SHA}" "${IMAGE}:${IMAGE_TAG}"
-  - docker push "${IMAGE}"
+  - docker tag "${REGISTRY}/${SOURCE}/{{ cookiecutter.docker_image }}:${CI_COMMIT_SHA}"
+               "${REGISTRY}/${TARGET}/{{ cookiecutter.docker_image }}:${IMAGE_TAG}"
+  - docker push "${REGISTRY}/${TARGET}/{{ cookiecutter.docker_image }}:${IMAGE_TAG}"
 
 {%- else -%}
 


### PR DESCRIPTION
The image built with the GitOps deployment strategy is always built in the development environment and tagged with the related Git hash. For tagging the source needs to point there, and only the target to the target environment.