### PR TITLE
GitOps: Reduced README for micro-service, monitoring instructions, Maven

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -43,7 +43,7 @@
         "gitops"
     ],
     "gitops_project": "{% if cookiecutter.deployment_strategy == 'gitops' %}{{ cookiecutter.project_slug }}-gitops{% else %}(none){% endif %}",
-    "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com') + '/' + cookiecutter.vcs_account) }}",
+    "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com')) }}",
     "docker_image": "{{ cookiecutter.project_slug }}",
     "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -43,7 +43,7 @@
         "gitops"
     ],
     "gitops_project": "{% if cookiecutter.deployment_strategy == 'gitops' %}{{ cookiecutter.project_slug }}-gitops{% else %}(none){% endif %}",
-    "docker_registry": "{{ cookiecutter.cloud_platform.replace('APPUiO', 'registry.appuio.ch').replace('(none)', cookiecutter.vcs_platform.replace('Bitbucket.org', 'hub.docker.com').replace('GitHub.com', 'quay.io').replace('GitLab.com', 'registry.gitlab.com')) }}",
+    "docker_registry": "{% if cookiecutter.cloud_platform == 'APPUiO' %}registry.appuio.ch{% elif cookiecutter.vcs_platform == 'GitLab.com' %}registry.gitlab.com{% elif cookiecutter.vcs_platform == 'Bitbucket.org' %}hub.docker.com{% elif cookiecutter.vcs_platform == 'GitHub.com' %}quay.io{% else %}nexus.example.com{% endif %}",
     "docker_image": "{{ cookiecutter.project_slug }}",
     "registry_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
     "automation_user": "{{ cookiecutter.ci_service.replace('.yml', '').replace('.', '').replace('-steps', '').replace('travis', 'travis-ci') }}",
@@ -79,7 +79,7 @@
         "force"
     ],
     "_copy_without_render": [
-        "_/frameworks/Flask",
+        "_/frameworks/Flask/application/templates",
         "_/frameworks/Symfony",
         "_/frameworks/TYPO3"
     ]

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -20,7 +20,6 @@ class TestGitops:
             'ci_service': 'bitbucket-pipelines.yml',
             'cloud_platform': 'APPUiO',
             'docker_registry': 'registry.appuio.ch',
-            'monitoring': '(none)',
             'files_present': [
                 'bitbucket/.git/config',
                 'bitbucket/.gitignore',
@@ -178,7 +177,6 @@ class TestGitops:
             'ci_service': 'codeship-steps.yml',
             'cloud_platform': 'Rancher',
             'docker_registry': 'registry.rancher.example',
-            'monitoring': '(none)',
             'files_present': [
                 'codeship/.git/config',
                 'codeship/.gitignore',
@@ -239,7 +237,6 @@ class TestGitops:
             'ci_service': '.gitlab-ci.yml',
             'cloud_platform': 'Rancher',
             'docker_registry': 'registry.rancher.example',
-            'monitoring': 'Sentry',
             'files_present': [
                 'gitlab/.git/config',
                 'gitlab/.gitignore',
@@ -268,16 +265,6 @@ class TestGitops:
                     Integrate External Tools
                     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-                    :Sentry:
-                      - Add environment variable ``SENTRY_DSN`` in
-                        `Settings > CI/CD > Variables \
-<https://gitlab.com/company-or-username/gitlab/-/settings/ci_cd>`__
-                      - Delete secrets in your namespace and run a deployment \
-(to recreate them)
-                      - Configure `Error Tracking \
-<https://gitlab.com/company-or-username/gitlab/-/error_tracking>`__
-                        in `Settings > Operations > Error Tracking \
-<https://gitlab.com/company-or-username/gitlab/-/settings/operations>`__
                     :Image Registry:
                       - Add environment variable ``REGISTRY_PASSWORD`` in
                         `Settings > CI/CD > Variables \
@@ -364,8 +351,8 @@ class TestGitops:
 
     # pylint: disable=no-self-use,too-many-arguments,too-many-locals
     def test_gitops(self, cookies, project_slug, framework, ci_service,
-                    cloud_platform, docker_registry, monitoring,
-                    files_present, files_absent, required_content):
+                    cloud_platform, docker_registry, files_present,
+                    files_absent, required_content):
         """
         Generate a project with a specific deployment strategy and verify
         it is complete and working.
@@ -377,7 +364,6 @@ class TestGitops:
             'ci_service': ci_service,
             'cloud_platform': cloud_platform,
             'docker_registry': docker_registry,
-            'monitoring': monitoring,
             'checks': 'kubernetes',
             'tests': 'test',
         })

--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -14,6 +14,6 @@ tox.ini
 README.rst
 tests/
 {%- elif cookiecutter.framework in ["SpringBoot"] %}
-README.md
+README.rst
 test/
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -38,8 +38,7 @@ Initial Setup
 {%- endif %}
 {%- if cookiecutter.cloud_platform in ['APPUiO'] %}
    at the `VSHN Control Panel <https://control.vshn.net/openshift/projects/appuio%20public>`_.
-{%- elif cookiecutter.cloud_platform in ['Rancher'] %}
-   with Rancher.
+{%- elif cookiecutter.cloud_platform in ['Rancher'] %} with Rancher.
 {%- endif %}
    For quota sizing consider roughly the sum of ``limits`` of all
    resources (must be strictly greater than the sum of ``requests``):
@@ -130,37 +129,39 @@ Initial Setup
 
 Integrate External Tools
 ^^^^^^^^^^^^^^^^^^^^^^^^
-{% set no_external_tools = 'Nothing to do here.' %}
-{% if cookiecutter.monitoring == 'Datadog' and cookiecutter.ci_service == '.gitlab-ci.yml' -%}
-{% set no_external_tools = '' -%}
+{% set ns = namespace(external_tools=false) %}
+{%- if cookiecutter.monitoring == 'Datadog' and cookiecutter.ci_service == '.gitlab-ci.yml' %}
+{%- set ns.external_tools = true %}
 :Datadog:
   - Add environment variables ``DATADOG_API_KEY``, ``DATADOG_APP_KEY``, ``DATADOG_APP_NAME`` in
     `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
   - Delete secrets in your namespace and run a deployment (to recreate them)
-{%- endif -%}
-{% if cookiecutter.monitoring == 'NewRelic' and cookiecutter.ci_service == '.gitlab-ci.yml' -%}
-{% set no_external_tools = '' -%}
+{%- endif %}
+{%- if cookiecutter.monitoring == 'NewRelic' and cookiecutter.ci_service == '.gitlab-ci.yml' %}
+{%- set ns.external_tools = true %}
 :New Relic:
   - Add environment variable ``NEWRELIC_LICENSE_KEY`` in
     `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
   - Delete secrets in your namespace and run a deployment (to recreate them)
-{%- endif -%}
-{% if cookiecutter.monitoring == 'Sentry' and cookiecutter.ci_service == '.gitlab-ci.yml' -%}
-{% set no_external_tools = '' -%}
+{%- endif %}
+{%- if cookiecutter.monitoring == 'Sentry' and cookiecutter.ci_service == '.gitlab-ci.yml' %}
+{%- set ns.external_tools = true %}
 :Sentry:
   - Add environment variable ``SENTRY_DSN`` in
     `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
   - Delete secrets in your namespace and run a deployment (to recreate them)
   - Configure `Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/error_tracking>`__
     in `Settings > Operations > Error Tracking <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/operations>`__
-{%- endif -%}
-{% if cookiecutter.docker_registry not in ['(none)', 'registry.appuio.ch', 'registry.gitlab.com'] and cookiecutter.ci_service == '.gitlab-ci.yml' -%}
-{% set no_external_tools = '' %}
+{%- endif %}
+{%- if cookiecutter.docker_registry not in ['(none)', 'registry.appuio.ch', 'registry.gitlab.com'] and cookiecutter.ci_service == '.gitlab-ci.yml' %}
+{%- set ns.external_tools = true %}
 :Image Registry:
   - Add environment variable ``REGISTRY_PASSWORD`` in
     `Settings > CI/CD > Variables <https://gitlab.com/{{ cookiecutter.vcs_account }}/{{ cookiecutter.vcs_project }}/-/settings/ci_cd>`__
-{%- endif -%}
-{{ no_external_tools }}
+{%- endif %}
+{%- if not ns.external_tools %}
+Nothing to do here.
+{%- endif %}
 
 Working with Docker
 ^^^^^^^^^^^^^^^^^^^

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -25,6 +25,8 @@ stages:
   stage: test
 {%- if cookiecutter.framework in ['Django', 'Flask'] %}
   image: docker.io/painless/tox
+{%- elif cookiecutter.framework in ['SpringBoot'] %}
+  image: docker.io/library/maven
 {%- else %}
   image: docker.io/painless/tox
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.gitlab-ci.yml
@@ -6,6 +6,6 @@
       {%- elif cookiecutter.framework in ['Symfony', 'TYPO3'] -%}
     echo "This should run {{ env }}"
       {%- elif cookiecutter.framework in ['SpringBoot'] -%}
-    echo "This should run {{ env }}"
+    mvn {{ env }}
       {%- endif %}
 {% endfor %}{% endif -%}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
@@ -9,6 +9,6 @@
         {%- elif cookiecutter.framework in ['Symfony', 'TYPO3'] %}
         - echo "This should run {{ env }}"
         {%- elif cookiecutter.framework in ['SpringBoot'] %}
-        - echo "This should run {{ env }}"
+        - mvn {{ env }}
         {%- endif %}
     {%- endfor -%}

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.in
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.in
@@ -1,14 +1,19 @@
 Django>=2.2.10,<3.0
 {%- if cookiecutter.monitoring == 'Datadog' %}
-django-datadog{% endif %}
+django-datadog
+{%- endif %}
 django-environ
 django-probes
 {%- if cookiecutter.database == 'MySQL' %}
-mysql-connector{% endif %}
+mysql-connector
+{%- endif %}
 {%- if cookiecutter.monitoring == 'NewRelic' %}
-newrelic{% endif %}
+newrelic
+{%- endif %}
 {%- if cookiecutter.database == 'Postgres' %}
-psycopg2{% endif %}
+psycopg2
+{%- endif %}
 {%- if cookiecutter.monitoring == 'Sentry' %}
-sentry-sdk{% endif %}
+sentry-sdk
+{%- endif %}
 uwsgi

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -5,22 +5,29 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 {%- if cookiecutter.monitoring == 'Sentry' %}
-certifi==2020.6.20        # via sentry-sdk{% endif %}
+certifi==2020.6.20        # via sentry-sdk
+{%- endif %}
 {%- if cookiecutter.monitoring == 'Datadog' %}
-django-datadog==1.0.1     # via -r requirements.in{% endif %}
+django-datadog==1.0.1     # via -r requirements.in
+{%- endif %}
 django-environ==0.4.5     # via -r requirements.in
 django-probes==1.5.0      # via -r requirements.in
 django==2.2.16            # via -r requirements.in
 {%- if cookiecutter.database == 'MySQL' %}
-mysql-connector==2.2.9    # via -r requirements.in{% endif %}
+mysql-connector==2.2.9    # via -r requirements.in
+{%- endif %}
 {%- if cookiecutter.monitoring == 'NewRelic' %}
-newrelic==5.20.0.149      # via -r requirements.in{% endif %}
+newrelic==5.20.0.149      # via -r requirements.in
+{%- endif %}
 {%- if cookiecutter.database == 'Postgres' %}
-psycopg2==2.8.6           # via -r requirements.in{% endif %}
+psycopg2==2.8.6           # via -r requirements.in
+{%- endif %}
 pytz==2020.1              # via django
 {%- if cookiecutter.monitoring == 'Sentry' %}
-sentry-sdk==0.17.7        # via -r requirements.in{% endif %}
+sentry-sdk==0.17.8        # via -r requirements.in
+{%- endif %}
 sqlparse==0.3.1           # via django
 {%- if cookiecutter.monitoring == 'Sentry' %}
-urllib3==1.25.10          # via sentry-sdk{% endif %}
+urllib3==1.25.10          # via sentry-sdk
+{%- endif %}
 uwsgi==2.0.19.1           # via -r requirements.in

--- a/{{cookiecutter.project_slug}}/_/frameworks/Flask/application/__init__.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Flask/application/__init__.py
@@ -1,10 +1,21 @@
+# pylint: disable=wrong-import-position
 """
 The Flask application.
 
 Taken from https://flask.palletsprojects.com/en/1.1.x/patterns/packages/
 """
+{%- if cookiecutter.monitoring == 'Sentry' %}
+import os
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+sentry_sdk.init(
+    dsn=os.environ.get('SENTRY_DSN'),
+    integrations=[FlaskIntegration()]
+)
+{% endif %}
 from flask import Flask
 
-app = Flask(__name__)  # noqa, pylint: disable=invalid-name
+app = Flask(__name__)
 
-import application.views  # noqa, pylint: disable=wrong-import-position
+import application.views

--- a/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.in
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.in
@@ -1,2 +1,5 @@
 Flask
+{%- if cookiecutter.monitoring == 'Sentry' %}
+sentry-sdk[flask]
+{%- endif %}
 uwsgi

--- a/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Flask/requirements.txt
@@ -4,10 +4,18 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+{%- if cookiecutter.monitoring == 'Sentry' %}
+blinker==1.4              # via sentry-sdk
+certifi==2020.6.20        # via sentry-sdk
+{%- endif %}
 click==7.1.2              # via flask
-flask==1.1.2              # via -r requirements.in
+flask==1.1.2              # via -r requirements.in{% if cookiecutter.monitoring == 'Sentry' %}, sentry-sdk{% endif %}
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 markupsafe==1.1.1         # via jinja2
+{%- if cookiecutter.monitoring == 'Sentry' %}
+sentry-sdk[flask]==0.17.8  # via -r requirements.in
+urllib3==1.25.10          # via sentry-sdk
+{%- endif %}
 uwsgi==2.0.19.1           # via -r requirements.in
 werkzeug==1.0.1           # via flask

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -104,12 +104,16 @@ summary = no
 [flake8]
 exclude = .cache,.git,.tox,build
 max-line-length = 88
+{%- if cookiecutter.framework == 'Flask' %}
+per-file-ignores =
+    application/__init__.py:E402,F401
+{%- endif %}
 
 [pylint]
 [MASTER]
-{% if cookiecutter.framework == 'Django' -%}
+{%- if cookiecutter.framework == 'Django' %}
 load-plugins = pylint_django
-{% endif -%}
+{%- endif %}
 output-format = colorized
 
 [pytest]


### PR DESCRIPTION
* We need to generate a reduced README for the micro-service when doing GitOps
* We run Java tests with Maven
* We add (and verify) monitoring setup instructions in the README
* Flask finally gets Sentry support