### PR TITLE
Provide sensible default tests for tests option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -65,8 +65,8 @@
         "simple",
         "complex"
     ],
-    "checks": "flake8,pylint,bandit,safety,kubernetes",
-    "tests": "py37,behave",
+    "checks": "{% if cookiecutter.framework in ['Django','Flask'] %}flake8,pylint,bandit,safety,kubernetes{% elif cookiecutter.framework in ['Symfony','TYPO3'] %}phpcs,twig,kubernetes{% elif cookiecutter.framework in ['SpringBoot'] %}kubernetes{% endif %}",
+    "tests": "{% if cookiecutter.framework in ['Django','Flask'] %}py37,behave{% elif cookiecutter.framework in ['Symfony','TYPO3'] %}phpunit{% elif cookiecutter.framework in ['SpringBoot'] %}test,verify{% endif %}",
     "monitoring": [
         "(none)",
         "Datadog",

--- a/tests/field/example-springboot.sh
+++ b/tests/field/example-springboot.sh
@@ -39,8 +39,6 @@ tox -e cookiecutter -- \
     environment_strategy=dedicated \
     deployment_strategy=gitops \
     framework=SpringBoot \
-    checks=kubernetes \
-    tests=junit \
     license=GPL-3 \
     push=force \
     ${*} \

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ passenv = *
 
 [testenv:fieldtest]
 description = Run a field test (skipping checks + tests)
+deps = tox
 commands = {toxinidir}/tests/field/example-{posargs:django}.sh checks= tests=
 passenv = *
 


### PR DESCRIPTION
Provides sensible default checks and tests for the related Cookiecutter options, for all supported frameworks.

Also fixes Tox running Tox, which is complaining since a recent local upgrade:
```python
tox.exception.Error: Error: break infinite loop provisioning within /usr/bin/python3 missing ['tox>=3.20.0']
```