### PR TITLE
Use valid hosts in Django's ALLOWED_HOSTS

### DIFF
--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -406,5 +406,4 @@ class TestGitops:
             for chunk in chunks:
                 assert chunk in file_content, \
                     'Not found in generated file %s:\n"%s"\n' \
-                    '-----------\n%s' % \
-                    (filename, chunk, file_content)
+                    '-----------\n%s' % (filename, chunk, file_content)

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -20,8 +20,8 @@ To start developing on this project simply bring up the Docker setup:
 Migrations will run automatically at startup (via the container entrypoint).
 If they fail the very first time simply restart the application.{% endif %}
 
-{% set port = '8080' if cookiecutter.framework == 'SpringBoot' else '5000' if cookiecutter.framework == 'Flask' else '8000' -%}
-Open your web browser at http://localhost:{{ port }} to see the application
+{% set port = ':8080' if cookiecutter.framework == 'SpringBoot' else ':8000' if cookiecutter.framework == 'Django' else ':5000' if cookiecutter.framework == 'Flask' else '' -%}
+Open your web browser at http://localhost{{ port }} to see the application
 you're developing.  Log output will be displayed in the terminal, as usual.
 
 For running tests, linting, security checks, etc. see instructions in the

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
@@ -28,7 +28,14 @@ DEBUG = env.bool('DJANGO_DEBUG', default=False)
 
 SECRET_KEY = 'dummy-secret' if DEBUG else env('DJANGO_SECRET_KEY')
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ['*'] if DEBUG else [
+{%- if cookiecutter.production_domain != '(automatic)' %}
+    '.{{ cookiecutter.production_domain }}',
+{%- endif%}
+{%- if cookiecutter.cloud_platform == 'APPUiO' %}
+    '.appuioapp.ch',
+{%- endif %}
+]
 
 LOGGING = {
     'version': 1,

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
@@ -31,7 +31,9 @@ SECRET_KEY = 'dummy-secret' if DEBUG else env('DJANGO_SECRET_KEY')
 ALLOWED_HOSTS = ['*'] if DEBUG else [
 {%- if cookiecutter.production_domain != '(automatic)' %}
     '.{{ cookiecutter.production_domain }}',
-{%- endif%}
+{%- else %}
+    # '.your.example.com',
+{%- endif %}
 {%- if cookiecutter.cloud_platform == 'APPUiO' %}
     '.appuioapp.ch',
 {%- endif %}


### PR DESCRIPTION
Restores some of [Django's intended security](https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts) by adding real host names to the Django `ALLOWED_HOSTS` settings.

Fixes #183.