### PR TITLE
Use the Tox image with preinstalled Go binaries

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
 .check:
   stage: check
 {%- if cookiecutter.framework in ['Django', 'Flask'] %}
-  image: docker.io/painless/tox
+  image: docker.io/painless/tox:kubernetes
 {%- else %}
   image: docker.io/appuio/oc:v3.11
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
@@ -2,7 +2,7 @@ options:
   docker: true
 
 {% if cookiecutter.framework in ['Django', 'Flask'] -%}
-image: docker.io/painless/tox
+image: docker.io/painless/tox:kubernetes
 
 {% endif -%}
 definitions:


### PR DESCRIPTION
This should shorten the pipeline execution time of the `kubernetes` job. It will definitely make the CI job more stable as downloading the related Go binaries is not necessary for the bigger [painless/tox:kubernetes](https://hub.docker.com/r/painless/tox) image that has them already on board.

**Related:** https://github.com/painless-software/kustomize-wrapper/pull/13