### PR TITLE
Also remove rolebindings when deleting review apps

### DIFF
--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -29,8 +29,8 @@ class TestCISetup:
                 '        - tox -e py37',
                 '                "Remove all related resources with > '
                 '  ++ USE WITH CAUTION ++\\n"',
-                '                "  oc delete all,configmap,pvc,secret'
-                ' -n ${TARGET} -l app=${LABEL}"',
+                '                "  oc delete all,configmap,pvc,rolebinding,'
+                'secret -n ${TARGET} -l app=${LABEL}"',
                 '    - &cleanup-resources',
                 '      seiso configmaps -l app=${LABEL} --delete &&',
                 '      seiso secrets -l app=${LABEL} --delete &&',
@@ -112,8 +112,8 @@ class TestCISetup:
                 '        - tox -e py37',
                 '                "Remove all related resources with > '
                 '  ++ USE WITH CAUTION ++\\n"',
-                '                "  oc delete all,configmap,pvc,secret'
-                ' -n ${TARGET} -l app=${LABEL}"',
+                '                "  oc delete all,configmap,pvc,rolebinding,'
+                'secret -n ${TARGET} -l app=${LABEL}"',
                 '    - &cleanup-resources',
                 '      seiso configmaps -l app=${LABEL} --delete &&',
                 '      seiso secrets -l app=${LABEL} --delete &&',
@@ -263,7 +263,8 @@ class TestCISetup:
                 '    kustomize build | oc apply -f - &&',
                 '    popd',
                 'stop_review:',
-                '  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}',  # noqa
+                '  - oc delete all,configmap,pvc,rolebinding,secret -n '
+                '${TARGET} -l app=${LABEL}',
                 '    auto_stop_in: 12 hours',
                 '    DATABASE_HOST: postgres-${CI_ENVIRONMENT_NAME}',
                 '    DATABASE_HOST: postgres-review-mr${CI_MERGE_REQUEST_IID}',
@@ -326,7 +327,8 @@ class TestCISetup:
                 '    kustomize build | oc apply -f - &&',
                 '    popd',
                 'stop_review:',
-                '  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}',  # noqa
+                '  - oc delete all,configmap,pvc,rolebinding,secret -n '
+                '${TARGET} -l app=${LABEL}',
                 '    auto_stop_in: 12 hours',
                 '    DATABASE_HOST: postgres',
                 '    DATABASE_HOST: postgres-review-mr${CI_MERGE_REQUEST_IID}',

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -53,7 +53,7 @@ stop_review:
   when: manual
   before_script:
   script:
-  - oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}
+  - oc delete all,configmap,pvc,rolebinding,secret -n ${TARGET} -l app=${LABEL}
 
 integration:
   extends: .deploy

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -68,7 +68,7 @@
                 "- https://${LABEL}-${TARGET}.appuioapp.ch/\n"
                 "\n"
                 "Remove all related resources with >   ++ USE WITH CAUTION ++\n"
-                "  oc delete all,configmap,pvc,secret -n ${TARGET} -l app=${LABEL}"
+                "  oc delete all,configmap,pvc,rolebinding,secret -n ${TARGET} -l app=${LABEL}"
 
   - step: &deploy-integration
       name: Deploy to Integration


### PR DESCRIPTION
We're [adding a suffix](https://github.com/painless-software/painless-continuous-delivery/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/_/ci-services/definitions/.gitlab-ci.yml#L134-L136) to all resources of a review app in the pipeline with Kustomize. Hence, also [RoleBinding](https://github.com/painless-software/painless-continuous-delivery/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/deployment/application/base/rolebinding.yaml)s are created as unique entities for each review app.

Until now [RoleBinding resources](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) were not deleted with review apps, which unnecessarily piled up more and more of stale resources. This PR fixes that behavior.