### PR TITLE
Simplify NGINX configuration for Python deployments

### DIFF
--- a/{{cookiecutter.project_slug}}/deployment/_/python/nginx.conf
+++ b/{{cookiecutter.project_slug}}/deployment/_/python/nginx.conf
@@ -1,8 +1,6 @@
 daemon off;
 worker_processes 1;
 
-include /etc/nginx/modules/*.conf;
-
 events {
     worker_connections 1024;
 }
@@ -11,20 +9,16 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    client_max_body_size 10M;
+    server_tokens off;
+
     server {
-        listen 8080 default;
+        listen 8080 default_server;
 
-        client_max_body_size 10M;
-        server_tokens off;
-
-        location / {
-            include uwsgi_params;
-            uwsgi_pass 127.0.0.1:8000;
-        }
-
-        location /media {
-            root /app;
-            expires 30d;
+        location = /healthz {
+            access_log off;
+            default_type text/plain;
+            return 200;
         }
 
         location /static {
@@ -32,10 +26,14 @@ http {
             expires 30d;
         }
 
-        location /healthz {
-            access_log off;
-            default_type text/plain;
-            return 200;
+        location /media {
+            root /app;
+            expires 30d;
+        }
+
+        location / {
+            include uwsgi_params;
+            uwsgi_pass 127.0.0.1:8000;
         }
     }
 }


### PR DESCRIPTION
Reduce the content of our webserver configuration:

- There are no NGINX modules available in the container image we use
- The `default` keyword is now called `default_server`
- An exact match makes the probes endpoint processed faster
- Reorder locations from specific to broad, static to dynamic