### PR TITLE
Newer Docker clients require the --all-tags option

### DIFF
--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -53,10 +53,12 @@ stages:
   before_script:
   - IMAGE=${REGISTRY}/${TARGET}/{{ cookiecutter.docker_image }}
   - docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
-  - docker pull "${IMAGE}:latest" || true
+  - docker pull ${IMAGE}:latest || true
   script:
-  - docker build --cache-from ${IMAGE}:latest --tag "${IMAGE}:${CI_COMMIT_SHA}" .
-  - docker push "${IMAGE}"
+  - docker build --cache-from ${IMAGE}:latest
+                 --tag ${IMAGE}:${CI_COMMIT_SHA}
+                 --tag ${IMAGE}:latest .
+  - docker push ${IMAGE} --all-tags
 
 {% if cookiecutter.deployment_strategy == 'gitops' -%}
 .tag-image:

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/bitbucket-pipelines.yml
@@ -16,11 +16,13 @@ definitions:
     - &docker-login
       docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
     - &build-image
-      docker build . -t "${IMAGE}:${BITBUCKET_COMMIT}"
+      docker build --cache-from ${IMAGE}:latest
+                   --tag ${IMAGE}:${BITBUCKET_COMMIT}
+                   --tag ${IMAGE}:latest .
     - &tag-image
       docker tag "${IMAGE}:${BITBUCKET_COMMIT}" "${IMAGE}:${IMAGE_TAG}"
     - &push-image
-      docker push "${IMAGE}"
+      docker push ${IMAGE} --all-tags
 {%- else %}
     - &define-vars
       DJANGO_SECRET_KEY=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c50)
@@ -45,10 +47,11 @@ definitions:
     - &docker-login
       docker login -u {{ cookiecutter.registry_user }} -p {% if cookiecutter.cloud_platform in ['APPUiO'] %}${KUBE_TOKEN}{% else %}${REGISTRY_PASSWORD}{% endif %} ${REGISTRY}
     - &build-image
-      docker build . -t "${IMAGE}:${BITBUCKET_COMMIT}"
-                     -t "${IMAGE}:latest"
+      docker build --cache-from ${IMAGE}:latest
+                   --tag ${IMAGE}:${BITBUCKET_COMMIT}
+                   --tag ${IMAGE}:latest .
     - &push-image
-      docker push "${IMAGE}"
+      docker push ${IMAGE} --all-tags
     - &generate-secrets-app
       oc get secret ${APPLICATION} ||
       oc create secret generic ${APPLICATION}


### PR DESCRIPTION
Deployments [started failing](https://gitlab.com/appuio/example-django/-/pipelines) on GitLab.com last Friday. It looks like a newer Docker client is now used in the public GitLab runners.

Older Docker clients (prior to version 20.03) pushed all images tags by default when an image name was provided without any tag. Newer clients only push the `latest` tag by default and now require the `--all-tags` option to push all available tags.