### PR TITLE
Use docker:latest image with Bitbucket Pipelines

### DIFF
--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -70,7 +70,7 @@ class TestGitops:
                     indent2("""
                     - step: &build
                         name: Build image
-                        image: docker.io/library/docker:19.03.8
+                        image: docker.io/library/docker:latest
                         caches:
                         - docker
                         script:
@@ -85,7 +85,7 @@ class TestGitops:
                     - step: &tag-review-app-image
                         name: Tag review app image
                         deployment: development
-                        image: docker.io/library/docker:19.03.8
+                        image: docker.io/library/docker:latest
                         caches:
                         - docker
                         script:
@@ -99,7 +99,7 @@ class TestGitops:
                     - step: &tag-integration-image
                         name: Tag integration image
                         deployment: integration
-                        image: docker.io/library/docker:19.03.8
+                        image: docker.io/library/docker:latest
                         caches:
                         - docker
                         script:
@@ -113,7 +113,7 @@ class TestGitops:
                     - step: &tag-production-image
                         name: Tag production image
                         deployment: production
-                        image: docker.io/library/docker:19.03.8
+                        image: docker.io/library/docker:latest
                         script:
                         - IMAGE_TAG=${BITBUCKET_TAG}
                         - *define-vars

--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 {% if cookiecutter.deployment_strategy == 'gitops' %}
   - step: &build
       name: Build image
-      image: docker.io/library/docker:19.03.8
+      image: docker.io/library/docker:latest
       caches:
       - docker
       script:
@@ -15,7 +15,7 @@
 {%- else %}
   - step: &build
       name: Build image
-      image: docker.io/library/docker:19.03.8
+      image: docker.io/library/docker:latest
       caches:
       - docker
       script:

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/bitbucket-pipelines.yml
@@ -2,7 +2,7 @@
   - step: &tag-review-app-image
       name: Tag review app image
       deployment: development
-      image: docker.io/library/docker:19.03.8
+      image: docker.io/library/docker:latest
       caches:
       - docker
       script:
@@ -15,7 +15,7 @@
   - step: &tag-integration-image
       name: Tag integration image
       deployment: integration
-      image: docker.io/library/docker:19.03.8
+      image: docker.io/library/docker:latest
       caches:
       - docker
       script:
@@ -28,7 +28,7 @@
   - step: &tag-production-image
       name: Tag production image
       deployment: production
-      image: docker.io/library/docker:19.03.8
+      image: docker.io/library/docker:latest
       script:
       - IMAGE_TAG=${BITBUCKET_TAG}
       - *define-vars


### PR DESCRIPTION
Using the `--all-tags` option with docker build requires a recent Docker client.

**Relates to:** #217 