### PR TITLE
Replace whitelist by allowlist, bash by console in markup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,13 @@ Usage
 
 Install `cookiecutter`_:
 
-.. code-block:: bash
+.. code-block:: console
 
     pip install cookiecutter
 
 Generate a new Cookiecutter template layout:
 
-.. code-block:: bash
+.. code-block:: console
 
     cookiecutter gh:painless-software/painless-continuous-delivery
 

--- a/generators/README.rst
+++ b/generators/README.rst
@@ -20,7 +20,7 @@ Philosophy
     skeletons in isolated virtual environments. The only thing you need to
     install on your cookiecutter development machine should be Tox itself:
 
-    .. code-block:: bash
+    .. code-block:: console
 
         pip install tox
 
@@ -30,14 +30,14 @@ Philosophy
 General Usage
 -------------
 
-.. code-block:: bash
+.. code-block:: console
 
     # list all available skeleton targets (= Tox targets)
     tox -l
     # list all skeleton targets for Django
     tox -l -c tox-django.ini
 
-.. code-block:: bash
+.. code-block:: console
 
     # generate all skeletons in the ./.tox/<target>/_/ folder
     tox
@@ -46,12 +46,12 @@ General Usage
     # generate only the skeleton for Django 1.11
     tox -e django111 -c tox-django.ini
 
-.. code-block:: bash
+.. code-block:: console
 
     # list all generated, sanitized skeletons
     ls -l .tox/*/_/
 
-.. code-block:: bash
+.. code-block:: console
 
     # remove skeletons, build files and folders
     tox -e clean

--- a/generators/tox-django.ini
+++ b/generators/tox-django.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{22,30}
+envlist = django{22,31}
 skip_install = True
 skipsdist = True
 
@@ -9,7 +9,7 @@ recreate = True
 deps =
     autopep8
     django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     django-debug-toolbar
     django-environ
     flake8-django
@@ -81,5 +81,5 @@ commands =
         -e 's/(\ndef main\(\):\n)/\1    """Main entry point of your Django application"""\n/' \
         -e 's/\n(\n    from django.core.management import)/\n    # pylint: disable=import-outside-toplevel\1/' \
         {toxworkdir}/{envname}/_/manage.py
-whitelist_externals =
+allowlist_externals =
     sed

--- a/generators/tox-symfony.ini
+++ b/generators/tox-symfony.ini
@@ -25,7 +25,7 @@ commands =
     sed -i _/composer.json -e 's#^    "scripts": {$#    "scripts": {\n        "test": [\n            "@composer phpunit"\n        ],#'
     sed -i _/composer.json -e 's#^    "scripts": {$#    "scripts": {\n        "check": [\n            "@composer phpcs",\n            "@composer twig"\n        ],#'
     echo ".env" >> .gitignore
-whitelist_externals =
+allowlist_externals =
     bash
     composer
     echo

--- a/generators/tox-typo3.ini
+++ b/generators/tox-typo3.ini
@@ -16,7 +16,7 @@ commands =
     {toxworkdir}/{envname}/vendor/bin/php-cs-fixer fix _
     bash -c "cd _ && rm -rf vendor web/{index.php,typo3}"
     echo ".env" >> .gitignore
-whitelist_externals =
+allowlist_externals =
     bash
     composer
     echo

--- a/generators/tox.ini
+++ b/generators/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 
 [testenv]
 passenv = *
-whitelist_externals = tox
+allowlist_externals = tox
 
 [testenv:django]
 commands = tox -c tox-django.ini
@@ -21,7 +21,7 @@ commands = tox -c tox-typo3.ini
 
 [testenv:clean]
 commands = rm -rf {toxworkdir}
-whitelist_externals = rm
+allowlist_externals = rm
 
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps = pyclean
 commands =
     pyclean {toxinidir}
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-projects
-whitelist_externals =
+allowlist_externals =
     rm
 
 [testenv:flake8]

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -39,9 +39,9 @@ commands =
 description = Remove bytecode and other debris
 deps = pyclean
 commands =
-    py3clean -v {toxinidir}
+    pyclean -v {toxinidir}
     rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
-whitelist_externals =
+allowlist_externals =
     rm
 
 [testenv:flake8]


### PR DESCRIPTION
1. Tox changed the use of whitelist/blacklist last summer as a result of the Black Lives Matter movement.
1. Instead of `bash` we use the more generic `console` for markup depicting console output or input
1. Django version 3.0 is now superseded by version 3.1 (generators setup only)
1. PyClean now has a modern implementation that is platform independent (`pyclean` command)