### PR TITLE
Use pyproject.toml for tool config, drop Python 3.7, relocate test reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ coverage.xml
 nosetests.xml
 unittests.xml
 .pytest_cache/
-tests/reports/
+tests/*-report.json
+tests/*-report.xml
+tests/TESTS-*.xml
 
 # Translations
 *.mo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ image: painless/tox:multi
   stage: test
   artifacts:
     reports:
-      junit: tests/reports/*.xml
+      junit: tests/*-report.xml
 
 stages:
 - check
@@ -37,10 +37,6 @@ bandit:
   stage: check
   script: tox -e bandit
   allow_failure: true
-
-py37:
-  extends: .test
-  script: tox -e py37
 
 py38:
   extends: .test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os: linux
 dist: bionic
 language: python
 python:
-- 3.7
 - 3.8
 - pypy3
 
@@ -15,10 +14,10 @@ stages:
 
 jobs:
   include:
-  - { stage: lint, python: 3.7, env: TOXENV=flake8 }
-  - { stage: lint, python: 3.7, env: TOXENV=pylint }
-  - { stage: lint, python: 3.7, env: TOXENV=bandit }
-  - { stage: test, python: 3.7, env: TOXENV=behave }
+  - { stage: lint, python: 3.8, env: TOXENV=flake8 }
+  - { stage: lint, python: 3.8, env: TOXENV=pylint }
+  - { stage: lint, python: 3.8, env: TOXENV=bandit }
+  - { stage: test, python: 3.8, env: TOXENV=behave }
 
   allow_failures:
   - env: TOXENV=bandit

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ This project adheres to `Semantic Versioning <https://semver.org>`__.
 0.7.0 (unreleased)
 ------------------
 
-- Drop Python 3.6 from Tox configurations
+- Introduce pyproject.toml for tool configuration
+- Drop Python 3.6 and 3.7 from Tox configurations and CI
 - Upgrade Django to 3.2 LTS and 4.0 (both use pathlib in settings)
 - Migrate Python setup to 3.8 on Alpine (from 3.7 on Debian)
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -25,10 +25,6 @@ definitions:
 
   - parallel: &tests
     - step:
-        name: Python 3.7
-        script:
-        - tox -e py37
-    - step:
         name: Python 3.8
         script:
         - tox -e py38

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -16,8 +16,6 @@
   type: parallel
   service: app
   steps:
-  - name: Python 3.7
-    command: tox -e py37
   - name: Python 3.8
     command: tox -e py38
   - name: PyPy 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.bandit]
+exclude = [".cache",".git",".idea",".tox",".vscode","build","dist","docs","tests"]
+
+[tool.black]
+color = true
+
+[tool.isort]
+color_output = true
+profile = "black"
+
+[tool.pylint.master]
+output-format = "colorized"
+
+[tool.pylint.messages_control]
+disable = [
+    # "duplicate-code",
+]
+
+[tool.pylint.similarities]
+min-similarity-lines = 6
+
+[tool.pytest.ini_options]
+addopts = "--color=yes --doctest-modules --ignore=tests/acceptance/steps --junitxml=tests/unittests-report.xml --verbose tests"

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,8 +10,6 @@ env:
   - TOXENV=flake8
   - TOXENV=pylint
   - TOXENV=bandit
-  - TOXENV=py36
-  - TOXENV=py37
   - TOXENV=py38
   - TOXENV=pypy3
   - TOXENV=behave
@@ -24,4 +22,4 @@ build:
   ci:
   - pip install tox
   - tox
-  - mv -v tests/reports/* shippable/testresults/ || true
+  - mv -v tests/*-report.* tests/TESTS-*.xml shippable/testresults/ || true

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -38,7 +38,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 .. code-block:: console
 
     # run a specific set of tests (one or several)
-    tox -e py37
+    tox -e py38
     tox -e flake8,pylint
 
 .. code-block:: console
@@ -74,7 +74,7 @@ missing ones, and fix identified issues (if any) with additional commits:
 
 .. code-block:: console
 
-    tox -e flake8,pylint,py36,py37
+    tox -e flake8,pylint,py38
 
 Field Tests
 -----------

--- a/tests/acceptance/features/python.feature
+++ b/tests/acceptance/features/python.feature
@@ -10,5 +10,5 @@ Feature: Painless Continuous Delivery project setup powered by Cookiecutter
 
     Examples: Python frameworks
       | framework | database | checks                   | tests       | commands |
-      | Django    | Postgres | flake8,pylint,kubernetes | py37,behave | tox      |
-      | Flask     | (none)   | flake8,pylint,kubernetes | py37,behave | tox      |
+      | Django    | Postgres | flake8,pylint,kubernetes | py38,behave | tox      |
+      | Flask     | (none)   | flake8,pylint,kubernetes | py38,behave | tox      |

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -22,11 +22,11 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit,kubernetes',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'required_lines': [
-                '        - tox -e py37',
+                '        - tox -e py38',
                 '                "Remove all related resources with > '
                 '  ++ USE WITH CAUTION ++\\n"',
                 '                "  oc delete all,configmap,pvc,rolebinding,'
@@ -105,11 +105,11 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit,kubernetes',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
             'required_lines': [
-                '        - tox -e py37',
+                '        - tox -e py38',
                 '                "Remove all related resources with > '
                 '  ++ USE WITH CAUTION ++\\n"',
                 '                "  oc delete all,configmap,pvc,rolebinding,'
@@ -208,7 +208,7 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'required_lines': [
@@ -224,12 +224,12 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'required_lines': [
                 '    TARGET: myproject',
-                '  script: tox -e py37',
+                '  script: tox -e py38',
                 '.deploy-vars:',
                 '.generate-secrets:',
                 '.deploy:',
@@ -291,12 +291,12 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'dedicated',
             'required_lines': [
                 '    TARGET: myproject-production',
-                '  script: tox -e py37',
+                '  script: tox -e py38',
                 '.deploy-vars:',
                 '.generate-secrets:',
                 '.deploy:',
@@ -372,7 +372,7 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'required_lines': [
@@ -388,7 +388,7 @@ class TestCISetup:
             'framework': 'Django',
             'database': 'Postgres',
             'checks': 'flake8,pylint,bandit',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'cloud_platform': 'APPUiO',
             'environment_strategy': 'shared',
             'required_lines': [

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -20,7 +20,7 @@ class TestFramework:
             'project_slug': 'django-project',
             'framework': 'Django',
             'checks': 'flake8,pylint',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'required_files': [
                 '.envrc',
                 '.gitignore',
@@ -81,7 +81,7 @@ class TestFramework:
             'project_slug': 'flask-project',
             'framework': 'Flask',
             'checks': 'flake8,pylint',
-            'tests': 'py36,py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'required_files': [
                 '.envrc',
                 '.gitignore',

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -20,11 +20,11 @@ class TestTestingSetup:
             'ci_service': '.travis.yml',
             'framework': 'Django',
             'checks': 'flake8,pylint,isort',
-            'tests': 'py37,py38,pypy3,behave',
+            'tests': 'py38,pypy3,behave',
             'test_configuration': [
                 ('tox.ini', [
                     '[tox]',
-                    'envlist = flake8,pylint,isort,py37,py38,pypy3,behave',
+                    'envlist = flake8,pylint,isort,py38,pypy3,behave',
                     '[testenv]',
                     '[testenv:flake8]',
                     '[testenv:isort]',
@@ -35,7 +35,7 @@ class TestTestingSetup:
                 ('pyproject.toml', [
                     '[tool.pylint.master]',
                     'load-plugins = "pylint_django"',
-                    '[tool.pytest]',
+                    '[tool.pytest.ini_options]',
                 ]),
             ],
             'match_project_root': [
@@ -49,11 +49,11 @@ class TestTestingSetup:
             'ci_service': '.travis.yml',
             'framework': 'Flask',
             'checks': 'isort',
-            'tests': 'py37,py38,behave',
+            'tests': 'py38,behave',
             'test_configuration': [
                 ('tox.ini', [
                     '[tox]',
-                    'envlist = isort,py37,py38,behave',
+                    'envlist = isort,py38,behave',
                     '[testenv]',
                     '[testenv:flake8]',
                     '[testenv:isort]',
@@ -63,7 +63,7 @@ class TestTestingSetup:
                 ]),
                 ('pyproject.toml', [
                     '[tool.pylint.master]',
-                    '[tool.pytest]',
+                    '[tool.pytest.ini_options]',
                 ]),
             ],
             'match_project_root': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pylint,bandit,py37,py38,pypy3,behave
+envlist = flake8,pylint,bandit,py38,pypy3,behave
 skipsdist = true
 
 [testenv]
@@ -14,7 +14,7 @@ description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
     pyclean {toxinidir}
-    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/ /tmp/painless-generated-projects
+    rm -rf .cache/ .pytest_cache/ .tox/ tests/*-report.* /tmp/painless-generated-projects
 allowlist_externals =
     rm
 
@@ -29,12 +29,12 @@ deps =
     {[testenv]deps}
     pylint
 commands =
-    pylint --rcfile tox.ini {posargs:tests hooks/post_gen_project.py}
+    pylint {posargs:tests hooks/post_gen_project.py}
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6.0
-commands = bandit -r --ini tox.ini
+deps = bandit
+commands = bandit -r _
 
 [testenv:behave]
 description = BDD acceptance test
@@ -59,34 +59,14 @@ deps = tox
 commands = {toxinidir}/tests/field/example-{posargs:django}.sh checks= tests=
 passenv = *
 
-[bandit]
-exclude = .cache,.git,.tox,build,dist,docs,tests,./*/_/frameworks/
-targets = .
-
 [behave]
 # default_format = progress
 default_tags = -@not_implemented -@xfail
 junit = yes
-junit_directory = tests/reports
+junit_directory = tests
 paths = tests/acceptance
 show_skipped = no
 summary = no
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
-
-[pylint]
-[MASTER]
-disable = duplicate-code
-min-similarity-lines = 5
-output-format = colorized
-
-[pytest]
-addopts =
-    --color=yes
-    --doctest-modules
-    --ignore=tests/acceptance/steps
-    --junitxml=tests/reports/unittests.xml
-    --strict
-    --verbose
-    tests

--- a/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/.travis.yml
@@ -6,8 +6,8 @@ dist: bionic
 {%- if cookiecutter.framework in ['Django', 'Flask'] %}
 language: python
 python:
-{%- for env in cookiecutter.tests.split(",")|select("in",["py36","py37","py38"]) %}
-- {{ env|replace('py36','3.6')|replace('py37','3.7')|replace('py38','3.8') }}
+{%- for env in cookiecutter.tests.split(",")|select("in",["py38","py39"]) %}
+- {{ env|replace('py38','3.8')|replace('py39','3.9') }}
 {%- endfor %}
 {%- elif cookiecutter.framework in ['Symfony', 'TYPO3'] %}
 language: php

--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/shippable.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/shippable.yml
@@ -9,4 +9,4 @@ build:
   {%- elif cookiecutter.framework in ['SpringBoot'] -%}
   - echo "This should run ???"
   {%- endif %}
-  - mv -v tests/reports/* shippable/testresults/ || true
+  - mv -v tests/*-report.* tests/TESTS-*xml shippable/testresults/ || true

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -32,7 +32,7 @@ stages:
 {%- endif %}
   artifacts:
     reports:
-      junit: tests/reports/*.xml
+      junit: tests/*-report.xml
   coverage: /^TOTAL.+ (\d+)%$/
   variables:
     GIT_DEPTH: 7

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.travis.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/.travis.yml
@@ -1,6 +1,6 @@
-{%- for env in cookiecutter.tests.split(",")|reject("in",["py36","py37","py38","pypy","pypy3"]) %}
+{%- for env in cookiecutter.tests.split(",")|reject("in",["py38","py39","pypy","pypy3"]) %}
   {%- if cookiecutter.framework in ['Django', 'Flask'] %}
-  - { stage: test, python: 3.7, env: TOXENV={{ env }} }
+  - { stage: test, python: 3.8, env: TOXENV={{ env }} }
   {%- elif cookiecutter.framework in ['Symfony', 'TYPO3'] %}
   - { stage: test, script: echo "This should run {{ env }}" }
   {%- elif cookiecutter.framework in ['SpringBoot'] %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/bitbucket-pipelines.yml
@@ -2,7 +2,7 @@
   - parallel: &tests
     {%- for env in cookiecutter.tests.split(",") %}
     - step:
-        name: {{ env|replace('py36','Python 3.6')|replace('py37','Python 3.7')|replace('py38','Python 3.8')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
+        name: {{ env|replace('py38','Python 3.8')|replace('py39','Python 3.9')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
         script:
         {%- if cookiecutter.framework in ['Django', 'Flask'] %}
         - tox -e {{ env }}

--- a/{{cookiecutter.project_slug}}/_/ci-services/test-stage/codeship-steps.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/test-stage/codeship-steps.yml
@@ -4,7 +4,7 @@
   service: app
   steps:
   {%- for env in cookiecutter.tests.split(',') %}
-  - name: {{ env|replace('py36','Python 3.6')|replace('py37','Python 3.7')|replace('py38','Python 3.8')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
+  - name: {{ env|replace('py38','Python 3.8')|replace('py39','Python 3.9')|replace('pypy3','PyPy 3')|replace('behave','Behave') }}
     command: {% if cookiecutter.framework in ['Django', 'Flask'] -%}
       tox -e {{ env }}
         {%- elif cookiecutter.framework in ['Symfony', 'TYPO3'] -%}

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/.gitignore
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/.gitignore
@@ -46,7 +46,9 @@ coverage.xml
 nosetests.xml
 unittests.xml
 .pytest_cache/
-tests/reports/
+tests/*-report.json
+tests/*-report.xml
+tests/TESTS-*.xml
 
 # Translations
 *.mo

--- a/{{cookiecutter.project_slug}}/_/frameworks/Flask/.gitignore
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Flask/.gitignore
@@ -46,7 +46,9 @@ coverage.xml
 nosetests.xml
 unittests.xml
 .pytest_cache/
-tests/reports/
+tests/*-report.json
+tests/*-report.xml
+tests/TESTS-*.xml
 
 # Translations
 *.mo

--- a/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
@@ -1,4 +1,14 @@
+[tool.bandit]
+exclude = [".cache",".git",".idea",".tox",".vscode","build","dist","docs","tests"]
+
+[tool.black]
+color = true
+
+[tool.coverage.xml]
+output = "tests/coverage-report.xml"
+
 [tool.isort]
+color_output = true
 profile = "black"
 
 [tool.pylint.master]
@@ -7,5 +17,8 @@ load-plugins = "pylint_django"
 {%- endif %}
 output-format = "colorized"
 
-[tool.pytest]
-addopts = "--color=yes --doctest-modules {% if cookiecutter.framework == 'Django' %}--ignore=application/urls.py --ignore=application/wsgi.py {% endif %}--ignore=tests/acceptance/steps --junitxml=tests/reports/unittests.xml --verbose"
+[tool.pylint.messages_control]
+disable = []
+
+[tool.pytest.ini_options]
+addopts = "--color=yes --doctest-modules {% if cookiecutter.framework == 'Django' %}--ignore=application/urls.py --ignore=application/wsgi.py {% endif %}--ignore=tests/acceptance/steps --junitxml=tests/unittests-report.xml --verbose"

--- a/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tests/README.rst
@@ -38,7 +38,7 @@ Use the ``tox`` command in the terminal to run your tests locally:
 .. code-block:: console
 
     # run a specific set of tests (one or several)
-    tox -e py37
+    tox -e py38
     tox -e flake8,pylint
 
 .. code-block:: console

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -5,10 +5,11 @@ skipsdist = true
 [testenv]
 description = Unit tests
 deps =
-    pytest-cov
     -r {toxinidir}/requirements.txt
+    coverage[toml]
+    pytest-cov
 commands =
-    pytest {posargs:--cov=application}
+    pytest --cov application --cov-report xml {posargs}
 {%- if cookiecutter.framework == 'Django' %}
 setenv =
     DJANGO_SECRET_KEY=testing
@@ -16,8 +17,8 @@ setenv =
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6.0
-commands = bandit -r --ini tox.ini
+deps = bandit
+commands = bandit -f json -o tests/bandit-report.json {posargs:-r application}
 
 [testenv:behave]
 description = Acceptence tests (BDD)
@@ -35,12 +36,17 @@ commands =
     behave {posargs}
 {%- endif %}
 
+[testenv:black]
+description = Ensure consitent code style
+deps = black
+commands = black --check --diff {posargs:application tests}
+
 [testenv:clean]
 description = Remove bytecode and other debris
 deps = pyclean
 commands =
-    pyclean -v {toxinidir}
-    rm -rf .cache/ .pytest_cache/ .tox/ tests/reports/
+    pyclean {toxinidir}
+    rm -rf .cache/ .pytest_cache/ .tox/ tests/*-report.*
 allowlist_externals =
     rm
 
@@ -51,8 +57,8 @@ commands = flake8 {posargs}
 
 [testenv:isort]
 description = Ensure consistent sort order of imports
-deps = isort
-commands = isort {posargs:--check}
+deps = isort[colors]
+commands = isort --check-only --diff {posargs:application tests}
 
 [testenv:kubernetes]
 description = Validate Kubernetes manifests
@@ -74,12 +80,12 @@ commands =
 [testenv:pylint]
 description = Check for errors and code smells
 deps =
-    pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
     -r {toxinidir}/requirements.txt
+    pylint{% if cookiecutter.framework == 'Django' %}-django{% endif %}
 commands =
     # generate module list:
     # $ ls */__init__.py | sed 's#/__init__.py# \\#g'
-    pylint --rcfile tox.ini {posargs:{% if cookiecutter.framework == 'Django' %}manage.py{% endif %} \
+    pylint {posargs:{% if cookiecutter.framework == 'Django' %}manage.py{% endif %} \
         application \
     }
 {%- if cookiecutter.framework == 'Django' %}
@@ -98,15 +104,11 @@ description = Check for vulnerable dependencies
 deps = safety
 commands = safety check --bare -r requirements.txt
 
-[bandit]
-exclude = .cache,.git,.tox,build,dist,docs,tests
-targets = .
-
 [behave]
 # default_format = progress
 default_tags = -@not_implemented -@xfail
 junit = yes
-junit_directory = tests/reports
+junit_directory = tests
 paths = tests/acceptance
 show_skipped = no
 summary = no


### PR DESCRIPTION
- Moves test tool configuration from `tox.ini` to `pyproject.toml`
- Drops use of Python 3.7 in Tox and CI jobs
- Makes test tools write their test reports in `tests/` folder directly (instead of `tests/reports/`) for simplicity