### PR TITLE
Rename default branch (master ➜ main), fix test setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ image: painless/tox:multi
   - git config --global user.name "Cookiecutter"
   - git config --global user.email "cookiecutter@painless.software"
   only:
-  - master
+  - main
 
 .test:
   stage: test

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ A cookiecutter for projects with continuous delivery baked in.
 .. |about| image:: https://img.shields.io/badge/About-Painless_Continuous_Delivery-44a0dd.svg
    :target: https://slides.com/bittner/djangocon2017-painless-continuous-delivery/
    :alt: Elevator pitch
-.. |health| image:: https://img.shields.io/codacy/grade/7aade15697ed4ad39758553efcd31c77/master.svg
+.. |health| image:: https://img.shields.io/codacy/grade/7aade15697ed4ad39758553efcd31c77/main.svg
    :target: https://www.codacy.com/app/painless/painless-continuous-delivery
    :alt: Code health
 
@@ -36,19 +36,19 @@ Supported Technologies and Services
 ==================== =========================================================
 
 
-.. |bitbucket| image:: https://img.shields.io/bitbucket/pipelines/painless-software/painless-continuous-delivery/master.svg
+.. |bitbucket| image:: https://img.shields.io/bitbucket/pipelines/painless-software/painless-continuous-delivery/main.svg
    :target: https://bitbucket.org/painless-software/painless-continuous-delivery/addon/pipelines/home
    :alt: Bitbucket Pipelines
-.. |codeship| image:: https://img.shields.io/codeship/5543c1f0-706e-0137-4541-72c064fff696/master.svg
+.. |codeship| image:: https://img.shields.io/codeship/5543c1f0-706e-0137-4541-72c064fff696/main.svg
    :target: https://app.codeship.com/projects/5543c1f0-706e-0137-4541-72c064fff696
    :alt: Codeship
-.. |gitlab-ci| image:: https://img.shields.io/gitlab/pipeline/painless-software/painless-continuous-delivery/master.svg
+.. |gitlab-ci| image:: https://img.shields.io/gitlab/pipeline/painless-software/painless-continuous-delivery/main.svg
    :target: https://gitlab.com/painless-software/painless-continuous-delivery/pipelines
    :alt: GitLab CI
-.. |shippable| image:: https://img.shields.io/shippable/5b3e90d82e388a070068d4bf/master.svg
+.. |shippable| image:: https://img.shields.io/shippable/5b3e90d82e388a070068d4bf/main.svg
    :target: https://app.shippable.com/projects/5b3e90d82e388a070068d4bf/
    :alt: Shippable
-.. |travis-ci| image:: https://img.shields.io/travis/painless-software/painless-continuous-delivery/master.svg
+.. |travis-ci| image:: https://img.shields.io/travis/painless-software/painless-continuous-delivery/main.svg
    :target: https://travis-ci.org/painless-software/painless-continuous-delivery
    :alt: Travis CI
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -50,7 +50,7 @@ pipelines:
     - parallel: *tests
 
   branches:
-    master:
+    main:
     - parallel: *checks
     - parallel: *tests
     - step: *field-test

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -25,7 +25,7 @@
 
 - name: Deploy staging
   type: serial
-  tag: master
+  tag: main
   service: app
   steps:
   - name: Staging

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -305,9 +305,9 @@ def deploy_field_test_for(local_project):
     shell = Shell(repo_path)
 
     if '{{ cookiecutter.push }}' == 'automatic':
-        shell.run('git push origin master')
+        shell.run('git push origin main')
     elif '{{ cookiecutter.push }}' == 'force':
-        shell.run('git push origin master --force')
+        shell.run('git push origin main --force')
 
 
 if __name__ == "__main__":

--- a/tests/field/example-django.sh
+++ b/tests/field/example-django.sh
@@ -122,7 +122,7 @@ git push -u origin feature/welcome-page --force
 log 5 'Create merge request'
 gitlab POST merge_requests \
     --form "source_branch=feature/welcome-page" \
-    --form "target_branch=master" \
+    --form "target_branch=main" \
     --form "title=Add friendly welcome page" \
     --form "description=A minimal Django application that shows some text. Tests are included." \
     > /dev/null
@@ -134,6 +134,6 @@ for minutes in $(seq 13 -1 1); do
 done
 
 log 7 'Trigger production release'
-git checkout master
+git checkout main
 git tag 1.0.0
 git push --tags --force

--- a/tests/field/example-flask.sh
+++ b/tests/field/example-flask.sh
@@ -54,6 +54,6 @@ for minutes in $(seq 13 -1 1); do
 done
 
 log 7 'Trigger production release'
-git checkout master
+git checkout main
 git tag 1.0.0
 git push --tags --force

--- a/tests/field/example-springboot.sh
+++ b/tests/field/example-springboot.sh
@@ -62,6 +62,6 @@ for minutes in $(seq 13 -1 1); do
 done
 
 log 7 'Trigger production release'
-git checkout master
+git checkout main
 git tag 1.0.0
 git push --tags --force

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -50,7 +50,7 @@ class TestDatabase:
             },
             'required_packages': [
                 'django-environ',
-                'psycopg',
+                'psycopg2',
             ],
         }),
         ('MySQL', {

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -132,7 +132,7 @@ class TestGitops:
                     """),
                     indent2("""
                       branches:
-                        master:
+                        main:
                         - parallel: *checks
                         - parallel: *tests
                         - step: *build
@@ -292,7 +292,7 @@ application/base/*.yaml application/overlays/*/*.yaml
                         name: development
                       only:
                       - merge_requests
-                      - master
+                      - main
                     """),
                     dedent("""
                     review:
@@ -312,7 +312,7 @@ application/base/*.yaml application/overlays/*/*.yaml
                       variables:
                         IMAGE_TAG: latest
                       only:
-                      - master
+                      - main
                     """),
                     dedent("""
                     production:

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -238,10 +238,10 @@ which will typically roll out our updated image immediately.
 - Any merge request automatically builds and pushes a review app image tagged
   ``{{ review_tag }}`` to the image registry.
 - Any change on the main branch, e.g. when a merge request is merged into
-  ``master``, builds and pushes an image tagged ``latest`` to the image
+  ``main``, builds and pushes an image tagged ``latest`` to the image
   registry, which is targeted for use on *integration*.
 - To mark an image "ready" for use on *production* push a Git tag on
-  the ``master`` branch, e.g.
+  the ``main`` branch, e.g.
 {%- else -%}
 {% if cookiecutter.environment_strategy == 'dedicated' -%}
 We have 3 environments corresponding to 3 namespaces on our container
@@ -255,13 +255,13 @@ on our container platform: *development*, *integration*, *production*
   When a merge request is merged or closed the review app will automatically
   be removed.
 - Any change on the main branch, e.g. when a merge request is merged into
-  ``master``, triggers a deployment on *integration*.
+  ``main``, triggers a deployment on *integration*.
 - To trigger a deployment on *production* push a Git tag, e.g.
 {%- endif %}
 
   .. code-block:: console
 
-    git checkout master
+    git checkout main
     git tag 1.0.0
     git push --tags
 

--- a/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/bitbucket-pipelines.yml
@@ -20,7 +20,7 @@ pipelines:
     {%- endif %}
 
   branches:
-    master:
+    main:
     {%- if cookiecutter.checks %}
     - parallel: *checks
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/_/ci-services/build-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/build-stage/.gitlab-ci.yml
@@ -5,4 +5,4 @@ app-image:
     name: development
   only:
   - merge_requests
-  - master
+  - main

--- a/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/definitions/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     GIT_DEPTH: 7
   only:
   - merge_requests
-  - master
+  - main
 
 .test:
   stage: test
@@ -38,7 +38,7 @@ stages:
     GIT_DEPTH: 7
   only:
   - merge_requests
-  - master
+  - main
 
 .build:
   stage: build

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/.gitlab-ci.yml
@@ -15,7 +15,7 @@ integration:
   variables:
     IMAGE_TAG: latest
   only:
-  - master
+  - main
 
 production:
   extends: .tag-image
@@ -69,7 +69,7 @@ integration:
 {%- endif %}
     IMAGE_TAG: ${CI_COMMIT_SHA}
   only:
-  - master
+  - main
 
 production:
   extends: .deploy

--- a/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/codeship-steps.yml
+++ b/{{cookiecutter.project_slug}}/_/ci-services/deploy-stage/codeship-steps.yml
@@ -1,7 +1,7 @@
 
 - name: Deploy staging
   type: serial
-  tag: master
+  tag: main
   service: app
   steps:
   - name: Staging

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/application/settings.py
@@ -172,7 +172,7 @@ if DEBUG:
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
     INSTALLED_APPS += ['debug_toolbar']
 
-if SECRET_KEY == 'testing':
+if SECRET_KEY == 'behave':
     INSTALLED_APPS += ['behave_django']
 {%- if cookiecutter.monitoring == 'Datadog' %}
 

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.in
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.in
@@ -11,7 +11,7 @@ mysql-connector
 newrelic
 {%- endif %}
 {%- if cookiecutter.database == 'Postgres' %}
-psycopg
+psycopg2
 {%- endif %}
 {%- if cookiecutter.monitoring == 'Sentry' %}
 sentry-sdk

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+asgiref==3.4.1
+    # via django
+django==3.2.12
+    # via -r requirements.in
 {%- if cookiecutter.monitoring == 'Sentry' %}
 certifi==2021.10.8
     # via sentry-sdk
@@ -16,8 +20,6 @@ django-environ==0.8.1
     # via -r requirements.in
 django-probes==1.6.0
     # via -r requirements.in
-django==3.2.12
-    # via -r requirements.in
 {%- if cookiecutter.database == 'MySQL' %}
 mysql-connector==2.2.9
     # via -r requirements.in
@@ -27,7 +29,7 @@ newrelic==7.4.0.172
     # via -r requirements.in
 {%- endif %}
 {%- if cookiecutter.database == 'Postgres' %}
-psycopg==3.0.8
+psycopg2==2.9.3
     # via -r requirements.in
 {%- endif %}
 pytz==2021.3
@@ -38,6 +40,8 @@ sentry-sdk==1.5.5
 {%- endif %}
 sqlparse==0.4.2
     # via django
+typing-extensions==4.1.1
+    # via asgiref
 {%- if cookiecutter.monitoring == 'Sentry' %}
 urllib3==1.26.8
     # via sentry-sdk

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -23,14 +23,14 @@ commands = bandit -f json -o tests/bandit-report.json {posargs:-r application}
 [testenv:behave]
 description = Acceptence tests (BDD)
 deps =
-    behave{% if cookiecutter.framework == 'Django' %}-django{% endif %}
     -r {toxinidir}/requirements.txt
+    behave{% if cookiecutter.framework == 'Django' %}-django{% endif %}
 {%- if cookiecutter.framework == 'Django' %}
 commands =
     python manage.py behave {posargs}
 setenv =
     DJANGO_DATABASE_URL=sqlite://
-    DJANGO_SECRET_KEY=testing
+    DJANGO_SECRET_KEY=behave
 {%- else %}
 commands =
     behave {posargs}


### PR DESCRIPTION
- Renames the default branch to remove terminology stemming from colonialism and slavery
- Reverts the upgrade to the Postgres psycopg v3 library, which is not yet supported by Django
- Fixes the test setup, which tried to load `behave-django` even it was not installed