### PR TITLE
Migrate from py.path to pathlib in cookiecutter tests

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -63,7 +63,7 @@
         "simple",
         "complex"
     ],
-    "checks": "{% if cookiecutter.framework in ['Django','Flask'] %}flake8,pylint,bandit,safety,kubernetes{% elif cookiecutter.framework in ['Symfony','TYPO3'] %}phpcs,twig,kubernetes{% elif cookiecutter.framework in ['SpringBoot'] %}kubernetes{% endif %}",
+    "checks": "{% if cookiecutter.framework in ['Django','Flask'] %}flake8,pylint,isort,bandit,safety,kubernetes{% elif cookiecutter.framework in ['Symfony','TYPO3'] %}phpcs,twig,kubernetes{% elif cookiecutter.framework in ['SpringBoot'] %}kubernetes{% endif %}",
     "tests": "{% if cookiecutter.framework in ['Django','Flask'] %}py38,behave{% elif cookiecutter.framework in ['Symfony','TYPO3'] %}phpunit{% elif cookiecutter.framework in ['SpringBoot'] %}test,verify{% endif %}",
     "monitoring": [
         "(none)",

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -390,17 +390,18 @@ class TestCISetup:
         assert result.exit_code == 0
         assert result.exception is None
 
-        assert result.project.basename == project_slug
-        assert result.project.isdir()
-        readme_file = result.project.join('README.rst')
-        assert readme_file.isfile()
+        assert result.project_path.name == project_slug
+        assert result.project_path.is_dir()
+        readme_file = result.project_path / 'README.rst'
+        assert readme_file.is_file()
 
-        readme_content = '\n'.join(readme_file.readlines(cr=False))
+        readme_content = '\n'.join(readme_file.read_text().splitlines())
         assert '\n\n\n' not in readme_content, \
             f"Excessive newlines in README: {readme_file}\n" \
             f"-------------\n{readme_content}"
 
-        ci_service_conf = result.project.join(ci_service).readlines(cr=False)
+        ci_service_conf = \
+            (result.project_path / ci_service).read_text().splitlines()
         ci_service_content = '\n'.join(ci_service_conf)
         assert '\n\n\n' not in ci_service_content, \
             "Excessive newlines in CI configuration."
@@ -415,13 +416,13 @@ class TestCISetup:
                 f"Found in CI config: '{chunk}'\n" \
                 f"{ci_service_content}"
 
-        codeship_services = result.project.join('codeship-services.yml')
+        codeship_services = result.project_path / 'codeship-services.yml'
         assert (ci_service == 'codeship-steps.yml' and
-                codeship_services.isfile()) or not codeship_services.exists()
+                codeship_services.is_file()) or not codeship_services.exists()
 
         files_absent = ['gitops', f"../{project_slug}-gitops"]
         for filename in files_absent:
-            thefile = result.project.join(filename)
+            thefile = result.project_path / filename
             assert not thefile.exists(), \
                 f'File {filename} found in generated project.'
 

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -1,7 +1,8 @@
 """
 Tests for generating a Web framework project.
 """
-from os import system
+
+from cli_test_helpers import shell
 
 from .helpers import (  # noqa, pylint: disable=unused-import
     dedent,
@@ -258,12 +259,12 @@ class TestFramework:
         assert result.exception is None
 
         for filename in required_files:
-            thefile = result.project.join(filename)
-            assert thefile.isfile(), \
+            thefile = result.project_path / filename
+            assert thefile.is_file(), \
                 f'File {filename} missing in generated project.'
 
         for filename, chunks in required_content:
-            file_content = result.project.join(filename).read()
+            file_content = (result.project_path / filename).read_text()
             for chunk in chunks:
                 assert chunk in file_content, \
                     f'Not found in generated file {filename}:\n' \
@@ -272,8 +273,10 @@ class TestFramework:
                     f'{file_content}'
 
         for cmd_pattern, project_file in install_commands:
-            input_file = result.project.join(project_file)
+            input_file = result.project_path / project_file
             command = cmd_pattern % input_file
-            assert input_file.isfile()
-            exit_code = system(command)
-            assert exit_code == 0, f'Command fails: {command}'
+            assert input_file.is_file()
+
+            run = shell(command)
+            # pylint: disable=no-member
+            assert run.exit_code == 0, f'Command fails: {command}'

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -375,37 +375,38 @@ application/base/*.yaml application/overlays/*/*.yaml
         assert result.exception is None
 
         for filename in files_present:
-            thefile = result.project.join("..", filename)
+            thefile = result.project_path.parent / filename
             assert thefile.exists(), \
                 f'File {filename} missing in generated project.'
 
         for filename in files_absent:
-            thefile = result.project.join('..').join(filename)
+            thefile = result.project_path.parent / filename
             assert not thefile.exists(), \
                 f'File {filename} found in generated project.'
 
-        app_readme_file = result.project.join("README.rst")
-        gitops_readme_file = result.project.join(
-            "..", f"{project_slug}-gitops", "README.rst")
+        app_readme_file = result.project_path / "README.rst"
+        gitops_readme_file = \
+            result.project_path.parent / f"{project_slug}-gitops" / "README.rst"
 
         for readme_file in [app_readme_file, gitops_readme_file]:
-            assert readme_file.isfile()
-            readme_content = '\n'.join(gitops_readme_file.readlines(cr=False))
+            assert readme_file.is_file()
+            readme_content = '\n'.join(gitops_readme_file.read_text().splitlines())
             assert '\n\n\n' not in readme_content, \
                 f"Excessive newlines in README: {readme_file}\n" \
                 f"-------------\n{readme_content}"
 
-        ci_service_conf = result.project.join(ci_service).readlines(cr=False)
+        ci_service_conf = (result.project_path / ci_service).read_text().splitlines()
         assert '\n\n\n' not in '\n'.join(ci_service_conf), \
             "Excessive newlines in micro-service CI config."
 
-        gitops_ci_conf = result.project.join(
-            "..", f"{project_slug}-gitops", ci_service).readlines(cr=False)
+        gitops_ci_conf = (
+            result.project_path.parent / f"{project_slug}-gitops" / ci_service
+        ).read_text().splitlines()
         assert '\n\n\n' not in '\n'.join(gitops_ci_conf), \
             "Excessive newlines in GitOps CI config."
 
         for filename, chunks in required_content:
-            file_content = result.project.join("..", filename).read()
+            file_content = (result.project_path.parent / filename).read_text()
             for chunk in chunks:
                 assert chunk in file_content, \
                     f'Not found in generated file {filename}:\n' \

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -374,17 +374,17 @@ class TestManifests:
         assert result.exit_code == 0
         assert result.exception is None
 
-        assert result.project.basename == 'myproject'
-        assert result.project.isdir()
-        self.manifests = result.project.join('manifests')
-        assert self.manifests.isdir()
+        assert result.project_path.name == 'myproject'
+        assert result.project_path.is_dir()
+        self.manifests = result.project_path / 'manifests'
+        assert self.manifests.is_dir()
 
         for filename in files_present:
-            assert self.manifests.join(filename).exists(), \
+            assert (self.manifests / filename).exists(), \
                 f"File or folder {filename} not found in manifests."
 
         for filename in files_absent:
-            assert not self.manifests.join(filename).exists(), \
+            assert not (self.manifests / filename).exists(), \
                 f"File or folder {filename} in manifests should be absent."
 
         self.verify_app_folders_exist()
@@ -394,7 +394,7 @@ class TestManifests:
 
         for filename, chunks in required_content:
             file_content = \
-                result.project.join('manifests').join(filename).read()
+                (result.project_path / 'manifests' / filename).read_text()
             for chunk in chunks:
                 assert chunk in file_content, \
                     f'Not found in generated file {filename}:\n' \
@@ -404,7 +404,7 @@ class TestManifests:
 
         for filename, chunks in absent_content:
             file_content = \
-                result.project.join('manifests').join(filename).read()
+                (result.project_path / 'manifests' / filename).read_text()
             for chunk in chunks:
                 assert chunk not in file_content, \
                     f'Found in file {filename}, but should not be present:\n' \
@@ -416,35 +416,35 @@ class TestManifests:
         """
         Set instance variables while checking on directories.
         """
-        self.app_config = self.manifests.join('application')
-        self.app_base = self.app_config.join('base')
-        self.app_overlays = self.app_config.join('overlays')
-        self.app_development = self.app_overlays.join('development')
-        self.app_integration = self.app_overlays.join('integration')
-        self.app_production = self.app_overlays.join('production')
+        self.app_config = self.manifests / 'application'
+        self.app_base = self.app_config / 'base'
+        self.app_overlays = self.app_config / 'overlays'
+        self.app_development = self.app_overlays / 'development'
+        self.app_integration = self.app_overlays / 'integration'
+        self.app_production = self.app_overlays / 'production'
 
-        assert self.app_base.isdir()
-        assert self.app_overlays.isdir()
-        assert self.app_development.isdir()
-        assert self.app_integration.isdir()
-        assert self.app_production.isdir()
+        assert self.app_base.is_dir()
+        assert self.app_overlays.is_dir()
+        assert self.app_development.is_dir()
+        assert self.app_integration.is_dir()
+        assert self.app_production.is_dir()
 
     def verify_db_folders_exist(self):
         """
         Set instance variables while checking on directories.
         """
-        self.db_config = self.manifests.join('database')
-        self.db_base = self.db_config.join('base')
-        self.db_overlays = self.db_config.join('overlays')
-        self.db_development = self.db_overlays.join('development')
-        self.db_integration = self.db_overlays.join('integration')
-        self.db_production = self.db_overlays.join('production')
+        self.db_config = self.manifests / 'database'
+        self.db_base = self.db_config / 'base'
+        self.db_overlays = self.db_config / 'overlays'
+        self.db_development = self.db_overlays / 'development'
+        self.db_integration = self.db_overlays / 'integration'
+        self.db_production = self.db_overlays / 'production'
 
-        assert self.db_base.isdir()
-        assert self.db_overlays.isdir()
-        assert self.db_development.isdir()
-        assert self.db_integration.isdir()
-        assert self.db_production.isdir()
+        assert self.db_base.is_dir()
+        assert self.db_overlays.is_dir()
+        assert self.db_development.is_dir()
+        assert self.db_integration.is_dir()
+        assert self.db_production.is_dir()
 
     def read_app_deployment_manifests(self):
         """
@@ -453,13 +453,13 @@ class TestManifests:
         self.verify_app_folders_exist()
 
         self.app_base_kustomize = \
-            self.app_base.join('kustomization.yaml').readlines(cr=False)
+            (self.app_base / 'kustomization.yaml').read_text().splitlines()
         self.app_development_kustomize = \
-            self.app_development.join('kustomization.yaml').readlines(cr=False)
+            (self.app_development / 'kustomization.yaml').read_text().splitlines()
         self.app_integration_kustomize = \
-            self.app_integration.join('kustomization.yaml').readlines(cr=False)
+            (self.app_integration / 'kustomization.yaml').read_text().splitlines()
         self.app_production_kustomize = \
-            self.app_production.join('kustomization.yaml').readlines(cr=False)
+            (self.app_production / 'kustomization.yaml').read_text().splitlines()
 
     def read_db_deployment_manifests(self):
         """
@@ -468,13 +468,13 @@ class TestManifests:
         self.verify_db_folders_exist()
 
         self.db_base_kustomize = \
-            self.db_base.join('kustomization.yaml').readlines(cr=False)
+            (self.db_base / 'kustomization.yaml').read_text().splitlines()
         self.db_development_kustomize = \
-            self.db_development.join('kustomization.yaml').readlines(cr=False)
+            (self.db_development / 'kustomization.yaml').read_text().splitlines()
         self.db_integration_kustomize = \
-            self.db_integration.join('kustomization.yaml').readlines(cr=False)
+            (self.db_integration / 'kustomization.yaml').read_text().splitlines()
         self.db_production_kustomize = \
-            self.db_production.join('kustomization.yaml').readlines(cr=False)
+            (self.db_production / 'kustomization.yaml').read_text().splitlines()
 
     def ensure_db_app_stay_aligned(self):
         """

--- a/tests/unit/test_repos.py
+++ b/tests/unit/test_repos.py
@@ -62,11 +62,12 @@ class TestRepos:
         assert result.exit_code == 0
         assert result.exception is None
 
-        assert result.project.basename == project_slug
-        assert result.project.isdir()
+        assert result.project_path.name == project_slug
+        assert result.project_path.is_dir()
 
-        assert result.project.join('.git').isdir()
-        git_config = result.project.join('.git', 'config').readlines(cr=False)
+        assert (result.project_path / '.git').is_dir()
+        git_config = \
+            (result.project_path / '.git' / 'config').read_text().splitlines()
         remote_section = '[remote "origin"]'
         remote_url = f'\turl = {vcs_remote}'
 
@@ -83,9 +84,10 @@ class TestRepos:
             f'{haystack}'
 
         image = f'image: {docker_registry}/{project_slug}'
+        docker_compose_final = result.project_path / 'docker-compose.final.yml'
         deploy_conf = [
-            line.strip() for line in result.project.join(
-                'docker-compose.final.yml').readlines(cr=False)
+            line.strip()
+            for line in docker_compose_final.read_text().splitlines()
             if line.strip()
         ]
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -130,7 +130,7 @@ class TestTestingSetup:
         assert result.exception is None
 
         for filename, expected_content in test_configuration:
-            config_file = result.project.join(filename).read()
+            config_file = (result.project_path / filename).read_text()
             for config_value in expected_content:
                 assert config_value in config_file, \
                     f'Config value missing in {filename}: {config_value}\n' \

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 description = Unit tests
 deps =
+    cli-test-helpers
     flake8
     pytest-cookies
 commands = pytest {posargs}
@@ -70,3 +71,4 @@ summary = no
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,docs,./*/_/frameworks/
+max-line-length = 88


### PR DESCRIPTION
The pytest-cookies Pytest plugin deprecated the `project` member of the Cookiecutter execution result. The new `project_path` member is a `pathlib.Path` object. The impact of this change is significant.

The `as_cwd()` context manager is not available in pathlib. We compensate this loss by using the `cwd` argument of the `subprocess.run` command. For convenience we use the [cli-test-helpers](https://pypi.org/project/cli-test-helpers/) implementation.