### PR TITLE
Declare Python IO encoding for console output

### DIFF
--- a/{{cookiecutter.project_slug}}/_/development/python/Dockerfile
+++ b/{{cookiecutter.project_slug}}/_/development/python/Dockerfile
@@ -2,8 +2,7 @@ FROM docker.io/library/python:3.8-alpine
 
 ARG REQUIREMENTS=requirements.txt
 
-ENV LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8 \
+ENV PYTHONIOENCODING=UTF-8 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /app


### PR DESCRIPTION
- Declares Python IO encoding for console output.
- Remove other declarations that are relevant mostly or only for Ubuntu.

Background reading: (StackOverflow)

- [Docker Python set utf-8 locale](https://stackoverflow.com/questions/43356982/docker-python-set-utf-8-locale)
- [What does PYTHONUNBUFFERED in Dockerfile do?](https://stackoverflow.com/questions/67447355/what-does-pythonunbuffered-in-dockerfile-do)