### PR TITLE
Configure pytest-django, revert Coverage setup

### DIFF
--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements-dev.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements-dev.txt
@@ -1,5 +1,4 @@
 -r requirements.in
 
 django-debug-toolbar
-tox-pipenv
 werkzeug

--- a/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
@@ -22,3 +22,8 @@ disable = []
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules {% if cookiecutter.framework == 'Django' %}--ignore=application/urls.py --ignore=application/wsgi.py {% endif %}--ignore=tests/acceptance/steps --junitxml=tests/unittests-report.xml --verbose"
+{%- if cookiecutter.framework == 'Django' %}
+DJANGO_SETTINGS_MODULE = "application.settings"
+FAIL_INVALID_TEMPLATE_VARS = true
+python_files = ["tests.py","test_*.py","*_tests.py"]
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -7,9 +7,11 @@ description = Unit tests
 deps =
     -r {toxinidir}/requirements.txt
     coverage[toml]
-    pytest-cov
+    pytest{% if cookiecutter.framework == 'Django' %}-django{% endif %}
 commands =
-    pytest --cov application --cov-report xml {posargs}
+    coverage run --source application -m pytest {posargs}
+    coverage xml
+    coverage report
 {%- if cookiecutter.framework == 'Django' %}
 setenv =
     DJANGO_SECRET_KEY=testing


### PR DESCRIPTION
[pytest-django](https://pytest-django.readthedocs.io/en/latest/index.html) needs a bit of preparation to get started.

The [pytest-cov](https://pytest-cov.readthedocs.io/) plugin for running Coverage.py has proven to be a bit unstable ([example](https://github.com/pytest-dev/pytest-cov/issues/523)).