### PR TITLE
Fix new Pylint complaints

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,3 +1,4 @@
+# pylint: disable=comparison-of-constants
 """Post-generate hook for cookiecutter."""
 
 import logging
@@ -7,7 +8,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 
 
-class Shell:  # pylint: disable=too-few-public-methods)
+class Shell:  # pylint: disable=too-few-public-methods
     """
     Command execution shell as a class to allow preserving behavior across
     execution calls.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -114,7 +114,7 @@ def verify_file_matches_repo_root(result, *file, max_compare_bytes=-1):
     """
     repo_root_path = Path(__file__).parent.parent.parent
     mother_file = repo_root_path.joinpath(*file)
-    mother_content = mother_file.read_text()[:max_compare_bytes]
+    mother_content = mother_file.read_text(encoding="utf-8")[:max_compare_bytes]
 
     generated_file = result.project_path.joinpath(*file)
     generated_content = generated_file.read_text()[:max_compare_bytes]

--- a/tests/unit/test_ci_setup.py
+++ b/tests/unit/test_ci_setup.py
@@ -366,7 +366,7 @@ class TestCISetup:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_ci_setup(self, cookies, project_slug, vcs_account, vcs_platform,
                       ci_service, framework, database, checks, tests,
                       cloud_platform, environment_strategy, required_lines,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -73,7 +73,7 @@ class TestDatabase:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_database(self, cookies, project_slug, framework, database,
                       required_settings, required_packages):
         """

--- a/tests/unit/test_framework.py
+++ b/tests/unit/test_framework.py
@@ -172,7 +172,7 @@ class TestFramework:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_framework(self, cookies, project_slug, framework, checks, tests,
                        required_files, required_content, install_commands):
         """

--- a/tests/unit/test_gitops.py
+++ b/tests/unit/test_gitops.py
@@ -352,7 +352,7 @@ application/base/*.yaml application/overlays/*/*.yaml
         }),
     ]
 
-    # pylint: disable=no-self-use,too-many-arguments,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_gitops(self, cookies, project_slug, framework, ci_service,
                     cloud_platform, docker_registry, files_present,
                     files_absent, required_content):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -191,7 +191,7 @@ class TestMonitoring:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_monitoring(self, cookies, project_slug, framework, monitoring,
                         cloud_platform, docker_registry, required_settings,
                         required_packages, required_content):

--- a/tests/unit/test_repos.py
+++ b/tests/unit/test_repos.py
@@ -41,7 +41,7 @@ class TestRepos:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_repos(self, cookies, project_slug, vcs_project, vcs_account,
                    vcs_platform, vcs_remote, ci_service, docker_registry):
         """

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -72,7 +72,7 @@ class TestTestingSetup:
         }),
     ]
 
-    # pylint: disable=too-many-arguments,too-many-locals,no-self-use
+    # pylint: disable=too-many-arguments,too-many-locals
     def test_testing(self, cookies, project_slug, vcs_account, vcs_platform,
                      ci_service, framework, checks, tests, test_configuration,
                      match_project_root):

--- a/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
+++ b/{{cookiecutter.project_slug}}/_/frameworks/Django/requirements.txt
@@ -6,12 +6,12 @@
 #
 asgiref==3.5.2
     # via django
-django==3.2.16
-    # via -r requirements.in
 {%- if cookiecutter.monitoring == 'Sentry' %}
 certifi==2022.9.24
     # via sentry-sdk
 {%- endif %}
+django==3.2.16
+    # via -r requirements.in
 {%- if cookiecutter.monitoring == 'Datadog' %}
 django-datadog==1.0.1
     # via -r requirements.in

--- a/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/_/testing/python/pyproject.toml
@@ -4,6 +4,12 @@ exclude = [".cache",".git",".idea",".tox",".vscode","build","dist","docs","tests
 [tool.black]
 color = true
 
+[tool.coverage.report]
+show_missing = true
+
+[tool.coverage.run]
+source = ["application"]
+
 [tool.coverage.xml]
 output = "tests/coverage-report.xml"
 

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -96,6 +96,7 @@ commands =
 setenv =
     DJANGO_SECRET_KEY=insecure
     DJANGO_SETTINGS_MODULE=application.settings
+    PYTHONPATH={toxinidir}
 {%- endif %}
 
 [testenv:requirements]

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = {{ cookiecutter.checks }}{% if cookiecutter.checks and cookiecutter.tests %},{% endif %}{{ cookiecutter.tests }},requirements
-skipsdist = true
 
 [testenv]
 description = Unit tests
+skip_install = true
 deps =
     -r {toxinidir}/requirements.txt
     coverage[toml]

--- a/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
+++ b/{{cookiecutter.project_slug}}/_/testing/python/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage[toml]
     pytest{% if cookiecutter.framework == 'Django' %}-django{% endif %}
 commands =
-    coverage run --source application -m pytest {posargs}
+    coverage run -m pytest {posargs}
     coverage xml
     coverage report
 {%- if cookiecutter.framework == 'Django' %}


### PR DESCRIPTION
Addresses or silences 3 types of complaints introduced in Pylint just recently:
 
- R0022: Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers. (useless-option-value)
- R0133: Comparison between constants: '{{ cookiecutter.database }} == ...' has a constant value (comparison-of-constants)
- W1514: Using open without explicitly specifying an encoding (unspecified-encoding)